### PR TITLE
[chore]: using tree-sitter-bash master branch now

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		28B3F010290C207D000CD04D /* CodeLanguages_Container.h in Headers */ = {isa = PBXBuildFile; fileRef = 28B3F00F290C207D000CD04D /* CodeLanguages_Container.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28B3F02A290C3570000CD04D /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F029290C3570000CD04D /* TreeSitterBash */; };
 		28B3F02D290C35D9000CD04D /* TreeSitterC in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F02C290C35D9000CD04D /* TreeSitterC */; };
 		28B3F030290C35F9000CD04D /* TreeSitterCPP in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F02F290C35F9000CD04D /* TreeSitterCPP */; };
 		28B3F033290C3608000CD04D /* TreeSitterCSharp in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F032290C3608000CD04D /* TreeSitterCSharp */; };
@@ -28,6 +27,7 @@
 		28B3F05D290C3709000CD04D /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F05C290C3709000CD04D /* TreeSitterSwift */; };
 		28B3F060290C3720000CD04D /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F05F290C3720000CD04D /* TreeSitterYAML */; };
 		28B3F063290C372D000CD04D /* TreeSitterZig in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F062290C372D000CD04D /* TreeSitterZig */; };
+		28B9F7AA290DDAC900245748 /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 28B9F7A9290DDAC900245748 /* TreeSitterBash */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,9 +48,9 @@
 				28B3F04B290C368B000CD04D /* TreeSitterJS in Frameworks */,
 				28B3F03C290C363E000CD04D /* TreeSitterGo in Frameworks */,
 				28B3F05D290C3709000CD04D /* TreeSitterSwift in Frameworks */,
+				28B9F7AA290DDAC900245748 /* TreeSitterBash in Frameworks */,
 				28B3F030290C35F9000CD04D /* TreeSitterCPP in Frameworks */,
 				28B3F04E290C3698000CD04D /* TreeSitterJSON in Frameworks */,
-				28B3F02A290C3570000CD04D /* TreeSitterBash in Frameworks */,
 				28B3F036290C361D000CD04D /* TreeSitterCSS in Frameworks */,
 				28B3F033290C3608000CD04D /* TreeSitterCSharp in Frameworks */,
 				28B3F03F290C364D000CD04D /* TreeSitterGoMod in Frameworks */,
@@ -137,7 +137,6 @@
 			);
 			name = "CodeLanguages-Container";
 			packageProductDependencies = (
-				28B3F029290C3570000CD04D /* TreeSitterBash */,
 				28B3F02C290C35D9000CD04D /* TreeSitterC */,
 				28B3F02F290C35F9000CD04D /* TreeSitterCPP */,
 				28B3F032290C3608000CD04D /* TreeSitterCSharp */,
@@ -157,6 +156,7 @@
 				28B3F05C290C3709000CD04D /* TreeSitterSwift */,
 				28B3F05F290C3720000CD04D /* TreeSitterYAML */,
 				28B3F062290C372D000CD04D /* TreeSitterZig */,
+				28B9F7A9290DDAC900245748 /* TreeSitterBash */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -187,7 +187,6 @@
 			);
 			mainGroup = 28B3F002290C207D000CD04D;
 			packageReferences = (
-				28B3F028290C3570000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-bash" */,
 				28B3F02B290C35D9000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-c" */,
 				28B3F02E290C35F9000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-cpp" */,
 				28B3F031290C3608000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-c-sharp" */,
@@ -207,6 +206,7 @@
 				28B3F05B290C3709000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
 				28B3F05E290C3720000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */,
 				28B3F061290C372D000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-zig" */,
+				28B9F7A6290DDAB500245748 /* XCRemoteSwiftPackageReference "tree-sitter-bash" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -446,14 +446,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		28B3F028290C3570000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-bash" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/lukepistrol/tree-sitter-bash.git";
-			requirement = {
-				branch = feature/spm;
-				kind = branch;
-			};
-		};
 		28B3F02B290C35D9000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-c" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tree-sitter/tree-sitter-c.git";
@@ -606,14 +598,17 @@
 				kind = branch;
 			};
 		};
+		28B9F7A6290DDAB500245748 /* XCRemoteSwiftPackageReference "tree-sitter-bash" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tree-sitter/tree-sitter-bash.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		28B3F029290C3570000CD04D /* TreeSitterBash */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 28B3F028290C3570000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-bash" */;
-			productName = TreeSitterBash;
-		};
 		28B3F02C290C35D9000CD04D /* TreeSitterC */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 28B3F02B290C35D9000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-c" */;
@@ -708,6 +703,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 28B3F061290C372D000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-zig" */;
 			productName = TreeSitterZig;
+		};
+		28B9F7A9290DDAC900245748 /* TreeSitterBash */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 28B9F7A6290DDAB500245748 /* XCRemoteSwiftPackageReference "tree-sitter-bash" */;
+			productName = TreeSitterBash;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,10 +21,10 @@
     {
       "identity" : "tree-sitter-bash",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lukepistrol/tree-sitter-bash.git",
+      "location" : "https://github.com/tree-sitter/tree-sitter-bash.git",
       "state" : {
-        "branch" : "feature/spm",
-        "revision" : "13af3b5b2c40d560aefeac28361d64f525d1869f"
+        "branch" : "master",
+        "revision" : "77cf8a7cab8904baf1a721762e012644ac1d4c7b"
       }
     },
     {

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-bash/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-bash/highlights.scm
@@ -46,7 +46,6 @@
   ">>"
   "<"
   "|"
-  (expansion_flags)
 ] @operator
 
 (


### PR DESCRIPTION
Since the SPM additions were merged into the master branch of `tree-sitter-bash` we now use the master branch directly.