### PR TITLE
[feat]: add `.jav` file extension to Java language definition

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-c-sharp.git",
       "state" : {
         "branch" : "master",
-        "revision" : "2162260aec4c7d7d4b43ef2287388adcc302c8d6"
+        "revision" : "98a28791018cc2587020a36b2d0cf28ccb29903f"
       }
     },
     {

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -1,0 +1,200 @@
+//
+//  CodeLanguage+Definitions.swift
+//  
+//
+//  Created by Lukas Pistrol on 15.01.23.
+//
+
+import Foundation
+
+public extension CodeLanguage {
+
+    /// An array of all language structures.
+    static let allLanguages: [CodeLanguage] = [
+        .bash,
+        .c,
+        .cpp,
+        .cSharp,
+        .css,
+        .dockerfile,
+        .elixir,
+        .go,
+        .goMod,
+        .haskell,
+        .html,
+        .java,
+        .javascript,
+        .json,
+        .jsx,
+        .php,
+        .python,
+        .ruby,
+        .rust,
+        .swift,
+        .yaml,
+        .zig
+    ]
+
+    /// A language structure for `Bash`
+    static let bash: CodeLanguage = .init(
+        id: .bash,
+        tsName: "bash",
+        extensions: ["sh"]
+    )
+
+    /// A language structure for `C`
+    static let c: CodeLanguage = .init(
+        id: .c,
+        tsName: "c",
+        extensions: ["c", "h", "o"]
+    )
+
+    /// A language structure for `C++`
+    static let cpp: CodeLanguage = .init(
+        id: .cpp,
+        tsName: "cpp",
+        extensions: ["cpp", "h", "hpp", "cc"],
+        parentURL: CodeLanguage.c.queryURL
+    )
+
+    /// A language structure for `C#`
+    static let cSharp: CodeLanguage = .init(
+        id: .cSharp,
+        tsName: "c-sharp",
+        extensions: ["cs"]
+    )
+
+    /// A language structure for `CSS`
+    static let css: CodeLanguage = .init(
+        id: .css,
+        tsName: "css",
+        extensions: ["css"]
+    )
+
+    /// A language structure for `Dockerfile`
+    static let dockerfile: CodeLanguage = .init(
+        id: .dockerfile,
+        tsName: "dockerfile",
+        extensions: ["Dockerfile"]
+    )
+
+    /// A language structure for `Elixir`
+    static let elixir: CodeLanguage = .init(
+        id: .elixir,
+        tsName: "elixir",
+        extensions: ["ex", "exs"]
+    )
+
+    /// A language structure for `Go`
+    static let go: CodeLanguage = .init(
+        id: .go,
+        tsName: "go",
+        extensions: ["go"]
+    )
+
+    /// A language structure for `GoMod`
+    static let goMod: CodeLanguage = .init(
+        id: .goMod,
+        tsName: "go-mod",
+        extensions: ["mod"]
+    )
+
+    /// A language structure for `Haskell`
+    static let haskell: CodeLanguage = .init(
+        id: .haskell,
+        tsName: "haskell",
+        extensions: ["hs"]
+    )
+
+    /// A language structure for `HTML`
+    static let html: CodeLanguage = .init(
+        id: .html,
+        tsName: "html",
+        extensions: ["html", "htm"]
+    )
+
+    /// A language structure for `Java`
+    static let java: CodeLanguage = .init(
+        id: .java,
+        tsName: "java",
+        extensions: ["java", "jav"]
+    )
+
+    /// A language structure for `JavaScript`
+    static let javascript: CodeLanguage = .init(
+        id: .javascript,
+        tsName: "javascript",
+        extensions: ["js"]
+    )
+
+    /// A language structure for `JSON`
+    static let json: CodeLanguage = .init(
+        id: .json,
+        tsName: "json",
+        extensions: ["json"]
+    )
+
+    /// A language structure for `JSX`
+    static let jsx: CodeLanguage = .init(
+        id: .jsx,
+        tsName: "javascript",
+        extensions: ["jsx"],
+        highlights: ["highlights-jsx"]
+    )
+
+    /// A language structure for `PHP`
+    static let php: CodeLanguage = .init(
+        id: .php,
+        tsName: "php",
+        extensions: ["php"]
+    )
+
+    /// A language structure for `Python`
+    static let python: CodeLanguage = .init(
+        id: .python,
+        tsName: "python",
+        extensions: ["py"]
+    )
+
+    /// A language structure for `Ruby`
+    static let ruby: CodeLanguage = .init(
+        id: .ruby,
+        tsName: "ruby",
+        extensions: ["rb"]
+    )
+
+    /// A language structure for `Rust`
+    static let rust: CodeLanguage = .init(
+        id: .rust,
+        tsName: "rust",
+        extensions: ["rs"]
+    )
+
+    /// A language structure for `Swift`
+    static let swift: CodeLanguage = .init(
+        id: .swift,
+        tsName: "swift",
+        extensions: ["swift"]
+    )
+
+    /// A language structure for `YAML`
+    static let yaml: CodeLanguage = .init(
+        id: .yaml,
+        tsName: "yaml",
+        extensions: ["yml", "yaml"]
+    )
+
+    /// A language structure for `Zig`
+    static let zig: CodeLanguage = .init(
+        id: .zig,
+        tsName: "zig",
+        extensions: ["zig"]
+    )
+
+    /// The default language (plain text)
+    static let `default`: CodeLanguage = .init(
+        id: .plainText,
+        tsName: "PlainText",
+        extensions: ["txt"]
+    )
+}

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -12,7 +12,7 @@ import CodeLanguages_Container
 
 /// A structure holding metadata for code languages
 public struct CodeLanguage {
-    private init(
+    internal init(
         id: TreeSitterLanguage,
         tsName: String,
         extensions: Set<String>,
@@ -134,109 +134,4 @@ public extension CodeLanguage {
             return .default
         }
     }
-
-    /// An array of all language structures.
-    static let allLanguages: [CodeLanguage] = [
-        .bash,
-        .c,
-        .cpp,
-        .cSharp,
-        .css,
-        .dockerfile,
-        .elixir,
-        .go,
-        .goMod,
-        .haskell,
-        .html,
-        .java,
-        .javascript,
-        .json,
-        .jsx,
-        .php,
-        .python,
-        .ruby,
-        .rust,
-        .swift,
-        .yaml,
-        .zig
-    ]
-
-    /// A language structure for `Bash`
-    static let bash: CodeLanguage = .init(id: .bash, tsName: "bash", extensions: ["sh"])
-
-    /// A language structure for `C`
-    static let c: CodeLanguage = .init(id: .c, tsName: "c", extensions: ["c", "h", "o"])
-
-    /// A language structure for `C++`
-    static let cpp: CodeLanguage = .init(
-        id: .cpp,
-        tsName: "cpp",
-        extensions: ["cpp", "h", "hpp", "cc"],
-        parentURL: CodeLanguage.c.queryURL
-    )
-
-    /// A language structure for `C#`
-    static let cSharp: CodeLanguage = .init(id: .cSharp, tsName: "c-sharp", extensions: ["cs"])
-
-    /// A language structure for `CSS`
-    static let css: CodeLanguage = .init(id: .css, tsName: "css", extensions: ["css"])
-
-    /// A language structure for `Dockerfile`
-    static let dockerfile: CodeLanguage = .init(id: .dockerfile, tsName: "dockerfile", extensions: ["Dockerfile"])
-
-    /// A language structure for `Elixir`
-    static let elixir: CodeLanguage = .init(id: .elixir, tsName: "elixir", extensions: ["ex", "exs"])
-
-    /// A language structure for `Go`
-    static let go: CodeLanguage = .init(id: .go, tsName: "go", extensions: ["go"])
-
-    /// A language structure for `GoMod`
-    static let goMod: CodeLanguage = .init(id: .goMod, tsName: "go-mod", extensions: ["mod"])
-
-    /// A language structure for `Haskell`
-    static let haskell: CodeLanguage = .init(id: .haskell, tsName: "haskell", extensions: ["hs"])
-
-    /// A language structure for `HTML`
-    static let html: CodeLanguage = .init(id: .html, tsName: "html", extensions: ["html", "htm"])
-
-    /// A language structure for `Java`
-    static let java: CodeLanguage = .init(id: .java, tsName: "java", extensions: ["java"])
-
-    /// A language structure for `JavaScript`
-    static let javascript: CodeLanguage = .init(id: .javascript, tsName: "javascript", extensions: ["js"])
-
-    /// A language structure for `JSON`
-    static let json: CodeLanguage = .init(id: .json, tsName: "json", extensions: ["json"])
-
-    /// A language structure for `JSX`
-    static let jsx: CodeLanguage = .init(
-        id: .jsx,
-        tsName: "javascript",
-        extensions: ["jsx"],
-        highlights: ["highlights-jsx"]
-    )
-
-    /// A language structure for `PHP`
-    static let php: CodeLanguage = .init(id: .php, tsName: "php", extensions: ["php"])
-
-    /// A language structure for `Python`
-    static let python: CodeLanguage = .init(id: .python, tsName: "python", extensions: ["py"])
-
-    /// A language structure for `Ruby`
-    static let ruby: CodeLanguage = .init(id: .ruby, tsName: "ruby", extensions: ["rb"])
-
-    /// A language structure for `Rust`
-    static let rust: CodeLanguage = .init(id: .rust, tsName: "rust", extensions: ["rs"])
-
-    /// A language structure for `Swift`
-    static let swift: CodeLanguage = .init(id: .swift, tsName: "swift", extensions: ["swift"])
-
-    /// A language structure for `YAML`
-    static let yaml: CodeLanguage = .init(id: .yaml, tsName: "yaml", extensions: ["yml", "yaml"])
-
-    /// A language structure for `Zig`
-    static let zig: CodeLanguage = .init(id: .zig, tsName: "zig", extensions: ["zig"])
-
-    /// The default language (plain text)
-    static let `default`: CodeLanguage = .init(id: .plainText, tsName: "Plain Text", extensions: ["txt"])
 }

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -82,6 +82,13 @@ final class CodeEditLanguagesTests: XCTestCase {
         XCTAssertEqual(language.id, .cpp)
     }
 
+    func test_CodeLanguageCPP3() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.hpp")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .cpp)
+    }
+
     func test_FetchQueryCPP() throws {
         var language = CodeLanguage.cpp
         language.resourceURL = bundleURL
@@ -262,6 +269,13 @@ final class CodeEditLanguagesTests: XCTestCase {
 
     func test_CodeLanguageJava() throws {
         let url = URL(fileURLWithPath: "~/path/to/file.java")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .java)
+    }
+
+    func test_CodeLanguageJava2() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.jav")
         let language = CodeLanguage.detectLanguageFrom(url: url)
 
         XCTAssertEqual(language.id, .java)


### PR DESCRIPTION
- add `.jav` file extension to Java language definition (closes #18)
- update C# language parser
- move language definitions to `CodeLangauge+Definitions.swift`