### PR TITLE
[feat]: Add YAML highlights

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		282E5977298051980064B34A /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 282E5976298051980064B34A /* TreeSitterYAML */; };
 		2846B262296BA1CF005F60B6 /* TreeSitterDockerfile in Frameworks */ = {isa = PBXBuildFile; productRef = 2846B261296BA1CF005F60B6 /* TreeSitterDockerfile */; };
 		28B3F010290C207D000CD04D /* CodeLanguages_Container.h in Headers */ = {isa = PBXBuildFile; fileRef = 28B3F00F290C207D000CD04D /* CodeLanguages_Container.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		28B3F02D290C35D9000CD04D /* TreeSitterC in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F02C290C35D9000CD04D /* TreeSitterC */; };
@@ -26,7 +27,6 @@
 		28B3F057290C36D5000CD04D /* TreeSitterRuby in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F056290C36D5000CD04D /* TreeSitterRuby */; };
 		28B3F05A290C36E5000CD04D /* TreeSitterRust in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F059290C36E5000CD04D /* TreeSitterRust */; };
 		28B3F05D290C3709000CD04D /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F05C290C3709000CD04D /* TreeSitterSwift */; };
-		28B3F060290C3720000CD04D /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F05F290C3720000CD04D /* TreeSitterYAML */; };
 		28B3F063290C372D000CD04D /* TreeSitterZig in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F062290C372D000CD04D /* TreeSitterZig */; };
 		28B9F7AA290DDAC900245748 /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 28B9F7A9290DDAC900245748 /* TreeSitterBash */; };
 /* End PBXBuildFile section */
@@ -61,7 +61,7 @@
 				28B3F05A290C36E5000CD04D /* TreeSitterRust in Frameworks */,
 				28B3F054290C36C5000CD04D /* TreeSitterPython in Frameworks */,
 				28B3F048290C367C000CD04D /* TreeSitterJava in Frameworks */,
-				28B3F060290C3720000CD04D /* TreeSitterYAML in Frameworks */,
+				282E5977298051980064B34A /* TreeSitterYAML in Frameworks */,
 				28B3F057290C36D5000CD04D /* TreeSitterRuby in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -156,10 +156,10 @@
 				28B3F056290C36D5000CD04D /* TreeSitterRuby */,
 				28B3F059290C36E5000CD04D /* TreeSitterRust */,
 				28B3F05C290C3709000CD04D /* TreeSitterSwift */,
-				28B3F05F290C3720000CD04D /* TreeSitterYAML */,
 				28B3F062290C372D000CD04D /* TreeSitterZig */,
 				28B9F7A9290DDAC900245748 /* TreeSitterBash */,
 				2846B261296BA1CF005F60B6 /* TreeSitterDockerfile */,
+				282E5976298051980064B34A /* TreeSitterYAML */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -207,10 +207,10 @@
 				28B3F055290C36D5000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-ruby" */,
 				28B3F058290C36E5000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-rust" */,
 				28B3F05B290C3709000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
-				28B3F05E290C3720000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */,
 				28B3F061290C372D000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-zig" */,
 				28B9F7A6290DDAB500245748 /* XCRemoteSwiftPackageReference "tree-sitter-bash" */,
 				2846B260296BA1CF005F60B6 /* XCRemoteSwiftPackageReference "tree-sitter-dockerfile" */,
+				282E5975298051980064B34A /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -450,6 +450,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		282E5975298051980064B34A /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lukepistrol/tree-sitter-yaml.git";
+			requirement = {
+				branch = feature/spm;
+				kind = branch;
+			};
+		};
 		2846B260296BA1CF005F60B6 /* XCRemoteSwiftPackageReference "tree-sitter-dockerfile" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/camdencheek/tree-sitter-dockerfile.git";
@@ -594,14 +602,6 @@
 				kind = branch;
 			};
 		};
-		28B3F05E290C3720000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mattmassicotte/tree-sitter-yaml.git";
-			requirement = {
-				branch = feature/spm;
-				kind = branch;
-			};
-		};
 		28B3F061290C372D000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-zig" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maxxnino/tree-sitter-zig.git";
@@ -621,6 +621,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		282E5976298051980064B34A /* TreeSitterYAML */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 282E5975298051980064B34A /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */;
+			productName = TreeSitterYAML;
+		};
 		2846B261296BA1CF005F60B6 /* TreeSitterDockerfile */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2846B260296BA1CF005F60B6 /* XCRemoteSwiftPackageReference "tree-sitter-dockerfile" */;
@@ -710,11 +715,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 28B3F05B290C3709000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-swift" */;
 			productName = TreeSitterSwift;
-		};
-		28B3F05F290C3720000CD04D /* TreeSitterYAML */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 28B3F05E290C3720000CD04D /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */;
-			productName = TreeSitterYAML;
 		};
 		28B3F062290C372D000CD04D /* TreeSitterZig */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-cpp.git",
       "state" : {
         "branch" : "master",
-        "revision" : "2d2c4aee8672af4c7c8edff68e7dd4c07e88d2b1"
+        "revision" : "3845ff48d6e370616cec189eb43ddce4fd57f4d4"
       }
     },
     {
@@ -183,10 +183,10 @@
     {
       "identity" : "tree-sitter-yaml",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattmassicotte/tree-sitter-yaml.git",
+      "location" : "https://github.com/lukepistrol/tree-sitter-yaml.git",
       "state" : {
         "branch" : "feature/spm",
-        "revision" : "bd633dc67bd71934961610ca8bd832bf2153883e"
+        "revision" : "1e4bf920c1f43cea89c8858ed5e0c10b098bb2b0"
       }
     },
     {

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/highlights.scm
@@ -1,0 +1,29 @@
+;; keys
+(block_mapping_pair
+ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable))
+(block_mapping_pair
+ key: (flow_node (plain_scalar (string_scalar) @variable)))
+
+;; keys within inline {} blocks
+(flow_mapping
+ (_ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable)))
+(flow_mapping
+ (_ key: (flow_node (plain_scalar (string_scalar) @variable))))
+
+["[" "]" "{" "}"] @punctuation.bracket
+["," "-" ":" "?" ">" "|"] @punctuation.delimiter
+["*" "&" "---" "..."] @punctuation.special
+
+[(null_scalar) (boolean_scalar)] @constant.builtin
+[(integer_scalar) (float_scalar)] @number
+[(double_quote_scalar) (single_quote_scalar) (block_scalar)] @string
+(escape_sequence) @escape
+
+(comment) @comment
+[(anchor_name) (alias_name)] @function
+(yaml_directive) @type
+
+(tag) @type
+(tag_handle) @type
+(tag_prefix) @string
+(tag_directive) @property

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -459,6 +459,16 @@ final class CodeEditLanguagesTests: XCTestCase {
         XCTAssertEqual(language.id, .yaml)
     }
 
+    func test_FetchQueryYAML() throws {
+        var language = CodeLanguage.yaml
+        language.resourceURL = bundleURL
+
+        let data = try Data(contentsOf: language.queryURL!)
+        let query = try? Query(language: language.language!, data: data)
+        XCTAssertNotNil(query)
+        XCTAssertNotEqual(query?.patternCount, 0)
+    }
+
     // YAML currently has no query files
 
 // MARK: - Zig

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -469,8 +469,6 @@ final class CodeEditLanguagesTests: XCTestCase {
         XCTAssertNotEqual(query?.patternCount, 0)
     }
 
-    // YAML currently has no query files
-
 // MARK: - Zig
 
     func test_CodeLanguageZig() throws {


### PR DESCRIPTION
Since a lot of `tree-sitter` language parser repositories seem to be inactive and a [PR](https://github.com/ikatyang/tree-sitter-yaml/pull/41) to add highlights to YAML is still not being reviewed, I added the file to a forked branch.

The result in `CodeEdit` will look something like this:

<img width="420" alt="Screenshot 2023-01-24 at 19 08 01" src="https://user-images.githubusercontent.com/9460130/214374222-c94493dc-8174-4a24-9f8e-b4b22644c1e7.png">

Refs: https://github.com/CodeEditApp/CodeEdit/discussions/1021
