### PR TITLE
Add ✅ to OCaml in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In order to add support for additional languages we have a complete guide on how
 | [Kotlin](https://github.com/lukepistrol/tree-sitter-kotlin/tree/feature/spm-queries) | ✅ | ✅ |
 | [Markdown](https://github.com/ikatyang/tree-sitter-markdown) |  | _not available_ |
 | [Objective C](https://github.com/lukepistrol/tree-sitter-objc/tree/feature/spm) | ✅ | ✅ |
-| [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml) |  |  |
+| [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml) | ✅ | ✅ |
 | Plain Text | ✅ | _not available_ |
 | [Perl](https://github.com/ganezdragon/tree-sitter-perl) |  | _not available_ |
 | [PHP](https://github.com/tree-sitter/tree-sitter-php) | ✅ | ✅ |


### PR DESCRIPTION
### This PR adds a ✅ to `OCaml` support in `README.md`
@lukepistrol needs to review this PR