### PR TITLE
[feat]: Add SQL parser

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		28171CB829814CD800523F1C /* TreeSitterObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 28171CB729814CD800523F1C /* TreeSitterObjC */; };
+		282C119329AA32C8004F1EA6 /* TreeSitterSQL in Frameworks */ = {isa = PBXBuildFile; productRef = 282C119229AA32C8004F1EA6 /* TreeSitterSQL */; };
 		282E5977298051980064B34A /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 282E5976298051980064B34A /* TreeSitterYAML */; };
 		2846B262296BA1CF005F60B6 /* TreeSitterDockerfile in Frameworks */ = {isa = PBXBuildFile; productRef = 2846B261296BA1CF005F60B6 /* TreeSitterDockerfile */; };
 		2886C788298135540023E016 /* TreeSitterKotlin in Frameworks */ = {isa = PBXBuildFile; productRef = 2886C787298135540023E016 /* TreeSitterKotlin */; };
@@ -48,6 +49,7 @@
 				28B3F051290C36B1000CD04D /* TreeSitterPHP in Frameworks */,
 				28B3F042290C365C000CD04D /* TreeSitterHaskell in Frameworks */,
 				2846B262296BA1CF005F60B6 /* TreeSitterDockerfile in Frameworks */,
+				282C119329AA32C8004F1EA6 /* TreeSitterSQL in Frameworks */,
 				28B3F039290C362C000CD04D /* TreeSitterElixir in Frameworks */,
 				28B3F02D290C35D9000CD04D /* TreeSitterC in Frameworks */,
 				28B3F04B290C368B000CD04D /* TreeSitterJS in Frameworks */,
@@ -169,6 +171,7 @@
 				2886C787298135540023E016 /* TreeSitterKotlin */,
 				28171CB729814CD800523F1C /* TreeSitterObjC */,
 				9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */,
+				282C119229AA32C8004F1EA6 /* TreeSitterSQL */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -223,6 +226,7 @@
 				2886C786298135540023E016 /* XCRemoteSwiftPackageReference "tree-sitter-kotlin" */,
 				28171CB629814CD800523F1C /* XCRemoteSwiftPackageReference "tree-sitter-objc" */,
 				9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */,
+				282C119129AA32C8004F1EA6 /* XCRemoteSwiftPackageReference "tree-sitter-sql" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -470,6 +474,14 @@
 				kind = branch;
 			};
 		};
+		282C119129AA32C8004F1EA6 /* XCRemoteSwiftPackageReference "tree-sitter-sql" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lukepistrol/tree-sitter-sql";
+			requirement = {
+				branch = feature/spm;
+				kind = branch;
+			};
+		};
 		282E5975298051980064B34A /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/lukepistrol/tree-sitter-yaml.git";
@@ -661,6 +673,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 28171CB629814CD800523F1C /* XCRemoteSwiftPackageReference "tree-sitter-objc" */;
 			productName = TreeSitterObjC;
+		};
+		282C119229AA32C8004F1EA6 /* TreeSitterSQL */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 282C119129AA32C8004F1EA6 /* XCRemoteSwiftPackageReference "tree-sitter-sql" */;
+			productName = TreeSitterSQL;
 		};
 		282E5976298051980064B34A /* TreeSitterYAML */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -199,6 +199,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-sql",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/tree-sitter-sql",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "6ad6e8f5297731881281f2309011559feee1ed84"
+      }
+    },
+    {
       "identity" : "tree-sitter-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alex-pinkus/tree-sitter-swift.git",

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-c.git",
       "state" : {
         "branch" : "master",
-        "revision" : "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
+        "revision" : "f35789006ccbe5be8db21d1a2dd4cc0b5a1286f2"
       }
     },
     {
@@ -33,7 +33,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-c-sharp.git",
       "state" : {
         "branch" : "master",
-        "revision" : "a29bac0681802139710b4d3875540901504d15cb"
+        "revision" : "3a5de1b38136add719c2e4dfba64359619745ae6"
       }
     },
     {
@@ -42,7 +42,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-cpp.git",
       "state" : {
         "branch" : "master",
-        "revision" : "56cec4c2eb5d6af3d2942e69e35db15ae2433740"
+        "revision" : "66262d3e76eb2046c76e6d661a6b72664bfb5819"
       }
     },
     {
@@ -60,7 +60,7 @@
       "location" : "https://github.com/camdencheek/tree-sitter-dockerfile.git",
       "state" : {
         "branch" : "main",
-        "revision" : "09e316dba307b869831e9399b11a83bbf0f2a24b"
+        "revision" : "8ee3a0f7587b2bd8c45c8cb7d28bd414604aec62"
       }
     },
     {
@@ -96,7 +96,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-haskell.git",
       "state" : {
         "branch" : "master",
-        "revision" : "aee3725d02cf3bca5f307b35dd3a96a97e109b4e"
+        "revision" : "3bdba07c7a8eec23f87fa59ce9eb2ea4823348b3"
       }
     },
     {
@@ -114,7 +114,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-java.git",
       "state" : {
         "branch" : "master",
-        "revision" : "dd597f13eb9bab0c1bccc9aec390e8e6ebf9e0a6"
+        "revision" : "3c24aa9365985830421a3a7b6791b415961ea770"
       }
     },
     {
@@ -123,7 +123,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-javascript.git",
       "state" : {
         "branch" : "master",
-        "revision" : "15e85e80b851983fab6b12dce5a535f5a0df0f9c"
+        "revision" : "5720b249490b3c17245ba772f6be4a43edb4e3b7"
       }
     },
     {
@@ -168,7 +168,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-php.git",
       "state" : {
         "branch" : "master",
-        "revision" : "973694ffcdeebca245b7ecf0d7c4cadd4f41b3c9"
+        "revision" : "f860e598194f4a71747f91789bf536b393ad4a56"
       }
     },
     {
@@ -195,7 +195,7 @@
       "location" : "https://github.com/tree-sitter/tree-sitter-rust.git",
       "state" : {
         "branch" : "master",
-        "revision" : "f7fb205c424b0962de59b26b931fe484e1262b35"
+        "revision" : "fbf9e507d09d8b3c0bb9dfc4d46c31039a47dc4a"
       }
     },
     {
@@ -204,7 +204,7 @@
       "location" : "https://github.com/lukepistrol/tree-sitter-sql",
       "state" : {
         "branch" : "feature/spm",
-        "revision" : "6ad6e8f5297731881281f2309011559feee1ed84"
+        "revision" : "fb79fdfb7413906a6ca2e0833c57d1cb38cc00f2"
       }
     },
     {
@@ -213,7 +213,7 @@
       "location" : "https://github.com/alex-pinkus/tree-sitter-swift.git",
       "state" : {
         "branch" : "with-generated-files",
-        "revision" : "50b8c5e61c29fa30e760c7a1cbf24b59970e6233"
+        "revision" : "b18cec3827e7a5d0223b5c14a70584ff1c7e2c62"
       }
     },
     {
@@ -231,7 +231,7 @@
       "location" : "https://github.com/maxxnino/tree-sitter-zig.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b0693dd473efd91d6085acd8e0ff9c627d37e077"
+        "revision" : "6b3f5788f38be900b45f5af5a753bf6a37d614b8"
       }
     }
   ],

--- a/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
+++ b/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
@@ -44,6 +44,7 @@ extern TSLanguage *tree_sitter_php();
 extern TSLanguage *tree_sitter_python();
 extern TSLanguage *tree_sitter_ruby();
 extern TSLanguage *tree_sitter_rust();
+extern TSLanguage *tree_sitter_sql();
 extern TSLanguage *tree_sitter_swift();
 extern TSLanguage *tree_sitter_yaml();
 extern TSLanguage *tree_sitter_zig();

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ In order to add support for additional languages we have a complete guide on how
 | [Ruby](https://github.com/mattmassicotte/tree-sitter-ruby) | ✅ | ✅ |
 | [Rust](https://github.com/tree-sitter/tree-sitter-rust) | ✅ | ✅ |
 | [Scala](https://github.com/tree-sitter/tree-sitter-scala) |  |  |
-| [Sql](https://github.com/m-novikov/tree-sitter-sql) |  |  |
-| [Swift](https://github.com/mattmassicotte/tree-sitter-swift) | ✅ | ✅ |
+| [Sql](https://github.com/lukepistrol/tree-sitter-sql/tree/feature/spm) | ✅ | ✅ |
+| [Swift](https://github.com/alex-pinkus/tree-sitter-swift/tree/with-generated-files) | ✅ | ✅ |
 | [TOML](https://github.com/ikatyang/tree-sitter-toml) |  |  |
 | [TypeScript/TSX](https://github.com/tree-sitter/tree-sitter-typescript) |  |  |
 | [Verilog](https://github.com/tree-sitter/tree-sitter-verilog) |  | _not available_ |

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -34,6 +34,7 @@ public extension CodeLanguage {
         .python,
         .ruby,
         .rust,
+        .sql,
         .swift,
         .yaml,
         .zig
@@ -200,6 +201,13 @@ public extension CodeLanguage {
         id: .rust,
         tsName: "rust",
         extensions: ["rs"]
+    )
+
+    /// A language structure for `SQL`
+    static let sql: CodeLanguage = .init(
+        id: .sql,
+        tsName: "sql",
+        extensions: ["sql"]
     )
 
     /// A language structure for `Swift`

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -112,6 +112,8 @@ public struct CodeLanguage {
             return tree_sitter_ruby()
         case .rust:
             return tree_sitter_rust()
+        case .sql:
+            return tree_sitter_sql()
         case .swift:
             return tree_sitter_swift()
         case .yaml:

--- a/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
@@ -41,6 +41,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - Python
 - Ruby
 - Rust
+- SQL
 - Swift
 - YAML
 - Zig
@@ -87,6 +88,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - ``python``
 - ``ruby``
 - ``rust``
+- ``sql``
 - ``swift``
 - ``yaml``
 - ``zig``

--- a/Sources/CodeEditLanguages/Documentation.docc/TreeSitterModel.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/TreeSitterModel.md
@@ -55,6 +55,7 @@ let query = TreeSitterModel.shared.swiftQuery
 - ``pythonQuery``
 - ``rubyQuery``
 - ``rustQuery``
+- ``sqlQuery``
 - ``swiftQuery``
 - ``yamlQuery``
 - ``zigQuery``

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-java/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-java/highlights.scm
@@ -73,6 +73,7 @@
   (character_literal)
   (string_literal)
 ] @string
+(escape_sequence) @string.escape
 
 [
   (true)

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-sql/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-sql/highlights.scm
@@ -1,0 +1,114 @@
+(string) @string
+(number) @number
+(comment) @comment
+
+(function_call
+    function: (identifier) @function)
+
+[
+  (NULL)
+  (TRUE)
+  (FALSE)
+] @constant.builtin
+
+([
+  (type_cast
+   (type (identifier) @type.builtin))
+  (create_function_statement
+   (type (identifier) @type.builtin))
+  (create_function_statement
+   (create_function_parameters
+     (create_function_parameter (type (identifier) @type.builtin))))
+  (create_type_statement
+    (type_spec_composite (type (identifier) @type.builtin)))
+  (create_table_statement
+   (table_parameters
+     (table_column (type (identifier) @type.builtin))))
+ ]
+ (#match?
+   @type.builtin
+    "^(bigint|BIGINT|int8|INT8|bigserial|BIGSERIAL|serial8|SERIAL8|bit|BIT|varbit|VARBIT|boolean|BOOLEAN|bool|BOOL|box|BOX|bytea|BYTEA|character|CHARACTER|char|CHAR|varchar|VARCHAR|cidr|CIDR|circle|CIRCLE|date|DATE|float8|FLOAT8|inet|INET|integer|INTEGER|int|INT|int4|INT4|interval|INTERVAL|json|JSON|jsonb|JSONB|line|LINE|lseg|LSEG|macaddr|MACADDR|money|MONEY|numeric|NUMERIC|decimal|DECIMAL|path|PATH|pg_lsn|PG_LSN|point|POINT|polygon|POLYGON|real|REAL|float4|FLOAT4|smallint|SMALLINT|int2|INT2|smallserial|SMALLSERIAL|serial2|SERIAL2|serial|SERIAL|serial4|SERIAL4|text|TEXT|time|TIME|time|TIME|timestamp|TIMESTAMP|tsquery|TSQUERY|tsvector|TSVECTOR|txid_snapshot|TXID_SNAPSHOT|enum|ENUM|range|RANGE)$"))
+
+(identifier) @variable
+
+[
+  "::"
+  "<"
+  "<="
+  "<>"
+  "="
+  ">"
+  ">="
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ";"
+  "."
+] @punctuation.delimiter
+
+[
+  (type)
+  (array_type)
+] @type
+
+[
+ (primary_key_constraint)
+ (unique_constraint)
+ (null_constraint)
+] @keyword
+
+[
+  "AND"
+  "AS"
+  "AUTO_INCREMENT"
+  "CREATE"
+  "CREATE_DOMAIN"
+  "CREATE_OR_REPLACE_FUNCTION"
+  "CREATE_SCHEMA"
+  "TABLE"
+  "TEMPORARY"
+  "CREATE_TYPE"
+  "DATABASE"
+  "FROM"
+  "GRANT"
+  "GROUP_BY"
+  "IF_NOT_EXISTS"
+  "INDEX"
+  "INNER"
+  "INSERT"
+  "INTO"
+  "IN"
+  "JOIN"
+  "LANGUAGE"
+  "LEFT"
+  "LOCAL"
+  "NOT"
+  "ON"
+  "OR"
+  "ORDER_BY"
+  "OUTER"
+  "PRIMARY_KEY"
+  "PUBLIC"
+  "RETURNS"
+  "SCHEMA"
+  "SELECT"
+  "SESSION"
+  "SET"
+  "TABLE"
+  "TIME_ZONE"
+  "TO"
+  "UNIQUE"
+  "UPDATE"
+  "USAGE"
+  "VALUES"
+  "WHERE"
+  "WITH"
+  "WITHOUT"
+] @keyword

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-swift/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-swift/highlights.scm
@@ -21,6 +21,7 @@
 (function_declaration ["init" @constructor])
 (throws) @keyword
 "async" @keyword
+"await" @keyword
 (where_keyword) @keyword
 (parameter external_name: (simple_identifier) @parameter)
 (parameter name: (simple_identifier) @parameter)
@@ -59,10 +60,10 @@
 (enum_entry ["case" @keyword])
 
 ; Function calls
-(call_expression (simple_identifier) @function) ; foo()
+(call_expression (simple_identifier) @function.call) ; foo()
 (call_expression ; foo.bar.baz(): highlight the baz()
   (navigation_expression
-    (navigation_suffix (simple_identifier) @function)))
+    (navigation_suffix (simple_identifier) @function.call)))
 ((navigation_expression
    (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
    (#match? @type "^[A-Z]"))
@@ -96,8 +97,10 @@
 (statement_label) @label
 
 ; Comments
-(comment) @comment
-(multiline_comment) @comment
+[
+ (comment)
+ (multiline_comment)
+] @comment @spell
 
 ; String literals
 (line_str_text) @string

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-zig/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-zig/highlights.scm
@@ -88,31 +88,40 @@ field_constant: (IDENTIFIER) @constant
 (EscapeSequence) @string.escape
 (FormatSequence) @string.special
 
-[
-  "allowzero"
-  "volatile"
-  "anytype"
-  "anyframe"
-  (BuildinTypeExpr)
-] @type.builtin
-
 (BreakLabel (IDENTIFIER) @label)
 (BlockLabel (IDENTIFIER) @label)
 
 [
-  "true"
-  "false"
-] @boolean
+  "asm"
+  "defer"
+  "errdefer"
+  "nosuspend"
+  "test"
+] @keyword
 
 [
-  "undefined"
-  "unreachable"
-  "null"
-] @constant.builtin
+  "fn"
+] @keyword.function
 
 [
-  "else"
+  "and"
+  "or"
+  "orelse"
+] @keyword.operator
+
+[
+  "return"
+  "break"
+  "continue"
+  "async"
+  "await"
+  "suspend"
+  "resume"
+] @keyword.return
+
+[
   "if"
+  "else"
   "switch"
 ] @conditional
 
@@ -122,73 +131,60 @@ field_constant: (IDENTIFIER) @constant
 ] @repeat
 
 [
-  "or"
-  "and"
-  "orelse"
-] @keyword.operator
-
-[
-  "struct"
-  "enum"
-  "union"
-  "error"
-  "packed"
-  "opaque"
-] @keyword
+  "usingnamespace"
+] @include
 
 [
   "try"
-  "error"
   "catch"
 ] @exception
 
-; VarDecl
+[
+  "anytype"
+  (BuildinTypeExpr)
+] @type.builtin
+
+[
+  "struct"
+  "union"
+  "enum"
+  "opaque"
+  "error"
+] @type.definition
+
 [
   "const"
   "var"
+  "volatile"
+  "allowzero"
+  "noalias"
+] @type.qualifier
+
+[
+  "addrspace"
+  "align"
+  "callconv"
+  "linksection"
+] @storageclass
+
+[
   "comptime"
-  "threadlocal"
-  "fn"
-] @keyword.function
-
-[
-  "test"
-  "pub"
-  "usingnamespace"
-] @keyword
-
-[
-  "return"
-  "break"
-  "continue"
-] @keyword.return
-
-; Macro
-[
-  "defer"
-  "errdefer"
-  "async"
-  "nosuspend"
-  "await"
-  "suspend"
-  "resume"
   "export"
   "extern"
-] @function.macro
-
-; PrecProc
-[
   "inline"
   "noinline"
-  "asm"
-  "callconv"
-  "noalias"
+  "packed"
+  "pub"
+  "threadlocal"
 ] @attribute
 
 [
-  "linksection"
-  "align" 
-] @function.builtin
+  "null"
+  "unreachable"
+  "undefined"
+  "true"
+  "false"
+] @constant.builtin
 
 [
   (CompareOp)

--- a/Sources/CodeEditLanguages/TreeSitterLanguage.swift
+++ b/Sources/CodeEditLanguages/TreeSitterLanguage.swift
@@ -32,6 +32,7 @@ public enum TreeSitterLanguage: String {
     case python
     case ruby
     case rust
+    case sql
     case swift
     case yaml
     case zig

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -66,6 +66,8 @@ public class TreeSitterModel {
             return rubyQuery
         case .rust:
             return rustQuery
+        case .sql:
+            return sqlQuery
         case .swift:
             return swiftQuery
         case .yaml:
@@ -190,6 +192,11 @@ public class TreeSitterModel {
     /// Query for `Rust` files.
     public private(set) lazy var rustQuery: Query? = {
         return queryFor(.rust)
+    }()
+
+    /// Query for `SQL` files.
+    public private(set) lazy var sqlQuery: Query? = {
+        return queryFor(.sql)
     }()
 
     /// Query for `Swift` files.

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -505,6 +505,25 @@ final class CodeEditLanguagesTests: XCTestCase {
         XCTAssertNotEqual(query?.patternCount, 0)
     }
 
+    // MARK: - SQL
+
+    func test_CodeLanguageSQL() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.sql")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .sql)
+    }
+
+    func test_FetchQuerySQL() throws {
+        var language = CodeLanguage.sql
+        language.resourceURL = bundleURL
+
+        let data = try Data(contentsOf: language.queryURL!)
+        let query = try? Query(language: language.language!, data: data)
+        XCTAssertNotNil(query)
+        XCTAssertNotEqual(query?.patternCount, 0)
+    }
+
 // MARK: - Swift
 
     func test_CodeLanguageSwift() throws {


### PR DESCRIPTION
This PR adds the [`tree-sitter-sql`](https://github.com/lukepistrol/tree-sitter-sql/tree/feature/spm) parser to `CodeEditLanguages`.

> The parser is still a fork of the official repo. It might stay that way, since the official repo does not track the `src/parser.c` file but relies on generating it on-the-fly using `node`.

Other language parsers have been updated to their latest versions:

- C
- C#
- C++
- Dockerfile
- Haskell
- Java
- JavaScript
- PHP
- Rust
- Swift
- Zig