### PR TITLE
Add Regex Language

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		28B3F05D290C3709000CD04D /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F05C290C3709000CD04D /* TreeSitterSwift */; };
 		28B3F063290C372D000CD04D /* TreeSitterZig in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F062290C372D000CD04D /* TreeSitterZig */; };
 		28B9F7AA290DDAC900245748 /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 28B9F7A9290DDAC900245748 /* TreeSitterBash */; };
-		6CAB9CA229C2CE0E006B8521 /* TreeSitterRegex in Frameworks */ = {isa = PBXBuildFile; productRef = 6CAB9CA129C2CE0E006B8521 /* TreeSitterRegex */; };
+		6CEC70FE29C3A85000B61C7A /* TreeSitterRegex in Frameworks */ = {isa = PBXBuildFile; productRef = 6CEC70FD29C3A85000B61C7A /* TreeSitterRegex */; };
 		9D6DA3B8298F1A4600E69066 /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */; };
 /* End PBXBuildFile section */
 
@@ -71,7 +71,7 @@
 				28B3F054290C36C5000CD04D /* TreeSitterPython in Frameworks */,
 				28171CB829814CD800523F1C /* TreeSitterObjC in Frameworks */,
 				28B3F048290C367C000CD04D /* TreeSitterJava in Frameworks */,
-				6CAB9CA229C2CE0E006B8521 /* TreeSitterRegex in Frameworks */,
+				6CEC70FE29C3A85000B61C7A /* TreeSitterRegex in Frameworks */,
 				282E5977298051980064B34A /* TreeSitterYAML in Frameworks */,
 				2886C788298135540023E016 /* TreeSitterKotlin in Frameworks */,
 				28B3F057290C36D5000CD04D /* TreeSitterRuby in Frameworks */,
@@ -177,7 +177,7 @@
 				9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */,
 				282C119229AA32C8004F1EA6 /* TreeSitterSQL */,
 				285BF67229AAA45B00641989 /* TreeSitterLua */,
-				6CAB9CA129C2CE0E006B8521 /* TreeSitterRegex */,
+				6CEC70FD29C3A85000B61C7A /* TreeSitterRegex */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -234,7 +234,7 @@
 				9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */,
 				282C119129AA32C8004F1EA6 /* XCRemoteSwiftPackageReference "tree-sitter-sql" */,
 				285BF67129AAA45B00641989 /* XCRemoteSwiftPackageReference "tree-sitter-lua" */,
-				6CAB9CA029C2CE0E006B8521 /* XCRemoteSwiftPackageReference "tree-sitter-regex" */,
+				6CEC70FC29C3A85000B61C7A /* XCRemoteSwiftPackageReference "tree-sitter-regex" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -674,11 +674,11 @@
 				kind = branch;
 			};
 		};
-		6CAB9CA029C2CE0E006B8521 /* XCRemoteSwiftPackageReference "tree-sitter-regex" */ = {
+		6CEC70FC29C3A85000B61C7A /* XCRemoteSwiftPackageReference "tree-sitter-regex" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/thecoolwinter/tree-sitter-regex";
+			repositoryURL = "https://github.com/thecoolwinter/tree-sitter-regex/";
 			requirement = {
-				branch = master;
+				branch = feature/spm;
 				kind = branch;
 			};
 		};
@@ -818,9 +818,9 @@
 			package = 28B9F7A6290DDAB500245748 /* XCRemoteSwiftPackageReference "tree-sitter-bash" */;
 			productName = TreeSitterBash;
 		};
-		6CAB9CA129C2CE0E006B8521 /* TreeSitterRegex */ = {
+		6CEC70FD29C3A85000B61C7A /* TreeSitterRegex */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6CAB9CA029C2CE0E006B8521 /* XCRemoteSwiftPackageReference "tree-sitter-regex" */;
+			package = 6CEC70FC29C3A85000B61C7A /* XCRemoteSwiftPackageReference "tree-sitter-regex" */;
 			productName = TreeSitterRegex;
 		};
 		9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */ = {

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		28B3F05D290C3709000CD04D /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F05C290C3709000CD04D /* TreeSitterSwift */; };
 		28B3F063290C372D000CD04D /* TreeSitterZig in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3F062290C372D000CD04D /* TreeSitterZig */; };
 		28B9F7AA290DDAC900245748 /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 28B9F7A9290DDAC900245748 /* TreeSitterBash */; };
+		6CAB9CA229C2CE0E006B8521 /* TreeSitterRegex in Frameworks */ = {isa = PBXBuildFile; productRef = 6CAB9CA129C2CE0E006B8521 /* TreeSitterRegex */; };
 		9D6DA3B8298F1A4600E69066 /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */; };
 /* End PBXBuildFile section */
 
@@ -70,6 +71,7 @@
 				28B3F054290C36C5000CD04D /* TreeSitterPython in Frameworks */,
 				28171CB829814CD800523F1C /* TreeSitterObjC in Frameworks */,
 				28B3F048290C367C000CD04D /* TreeSitterJava in Frameworks */,
+				6CAB9CA229C2CE0E006B8521 /* TreeSitterRegex in Frameworks */,
 				282E5977298051980064B34A /* TreeSitterYAML in Frameworks */,
 				2886C788298135540023E016 /* TreeSitterKotlin in Frameworks */,
 				28B3F057290C36D5000CD04D /* TreeSitterRuby in Frameworks */,
@@ -175,6 +177,7 @@
 				9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */,
 				282C119229AA32C8004F1EA6 /* TreeSitterSQL */,
 				285BF67229AAA45B00641989 /* TreeSitterLua */,
+				6CAB9CA129C2CE0E006B8521 /* TreeSitterRegex */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -231,6 +234,7 @@
 				9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */,
 				282C119129AA32C8004F1EA6 /* XCRemoteSwiftPackageReference "tree-sitter-sql" */,
 				285BF67129AAA45B00641989 /* XCRemoteSwiftPackageReference "tree-sitter-lua" */,
+				6CAB9CA029C2CE0E006B8521 /* XCRemoteSwiftPackageReference "tree-sitter-regex" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -670,6 +674,14 @@
 				kind = branch;
 			};
 		};
+		6CAB9CA029C2CE0E006B8521 /* XCRemoteSwiftPackageReference "tree-sitter-regex" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/thecoolwinter/tree-sitter-regex";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cengelbart39/tree-sitter-ocaml.git";
@@ -805,6 +817,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 28B9F7A6290DDAB500245748 /* XCRemoteSwiftPackageReference "tree-sitter-bash" */;
 			productName = TreeSitterBash;
+		};
+		6CAB9CA129C2CE0E006B8521 /* TreeSitterRegex */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CAB9CA029C2CE0E006B8521 /* XCRemoteSwiftPackageReference "tree-sitter-regex" */;
+			productName = TreeSitterRegex;
 		};
 		9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -190,6 +190,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-regex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/thecoolwinter/tree-sitter-regex",
+      "state" : {
+        "branch" : "master",
+        "revision" : "bcdbf846fa8cfce0d28971d43199e52c1e365aa7"
+      }
+    },
+    {
       "identity" : "tree-sitter-ruby",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tree-sitter/tree-sitter-ruby.git",

--- a/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
+++ b/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
@@ -43,6 +43,7 @@ extern TSLanguage *tree_sitter_ocaml();
 extern TSLanguage *tree_sitter_ocaml_interface();
 extern TSLanguage *tree_sitter_php();
 extern TSLanguage *tree_sitter_python();
+extern TSLanguage *tree_sitter_regex();
 extern TSLanguage *tree_sitter_ruby();
 extern TSLanguage *tree_sitter_rust();
 extern TSLanguage *tree_sitter_sql();

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In order to add support for additional languages we have a complete guide on how
 | [Perl](https://github.com/ganezdragon/tree-sitter-perl) |  | _not available_ |
 | [PHP](https://github.com/tree-sitter/tree-sitter-php) | ✅ | ✅ |
 | [Python](https://github.com/lukepistrol/tree-sitter-python) | ✅ | ✅ |
-| [Regex](https://github.com/tree-sitter/tree-sitter-regex) |  |  |
+| [Regex](https://github.com/tree-sitter/tree-sitter-regex) | ✅ | ✅ |
 | [Ruby](https://github.com/mattmassicotte/tree-sitter-ruby) | ✅ | ✅ |
 | [Rust](https://github.com/tree-sitter/tree-sitter-rust) | ✅ | ✅ |
 | [Scala](https://github.com/tree-sitter/tree-sitter-scala) |  |  |

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -33,6 +33,7 @@ public extension CodeLanguage {
         .ocamlInterface,
         .php,
         .python,
+        .regex,
         .ruby,
         .rust,
         .sql,
@@ -201,6 +202,13 @@ public extension CodeLanguage {
         id: .python,
         tsName: "python",
         extensions: ["py"]
+    )
+
+    /// A language structure for `Regex`
+    static let regex: CodeLanguage = .init(
+        id: .regex,
+        tsName: "regex",
+        extensions: []
     )
 
     /// A language structure for `Ruby`

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -110,6 +110,8 @@ public struct CodeLanguage {
             return tree_sitter_php()
         case .python:
             return tree_sitter_python()
+        case .regex:
+            return tree_sitter_regex()
         case .ruby:
             return tree_sitter_ruby()
         case .rust:

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-regex/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-regex/highlights.scm
@@ -1,0 +1,52 @@
+[
+  "("
+  ")"
+  "(?"
+  "(?:"
+  "(?<"
+  ">"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(group_name) @property
+
+[
+  (identity_escape)
+  (control_letter_escape)
+  (character_class_escape)
+  (control_escape)
+  (start_assertion)
+  (end_assertion)
+  (boundary_assertion)
+  (non_boundary_assertion)
+] @escape
+
+[
+  "*"
+  "+"
+  "?"
+  "|"
+  "="
+  "<="
+  "!"
+  "<!"
+] @operator
+
+(count_quantifier
+  [
+    (decimal_digits) @number
+    "," @punctuation.delimiter
+  ])
+
+(character_class
+  [
+    "^" @operator
+    (class_range "-" @operator)
+  ])
+
+(class_character) @constant.character
+
+(pattern_character) @string

--- a/Sources/CodeEditLanguages/TreeSitterLanguage.swift
+++ b/Sources/CodeEditLanguages/TreeSitterLanguage.swift
@@ -31,6 +31,7 @@ public enum TreeSitterLanguage: String {
     case ocamlInterface
     case php
     case python
+    case regex
     case ruby
     case rust
     case sql

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -195,7 +195,7 @@ public class TreeSitterModel {
 
     /// Query for `Regex` files.
     public private(set) lazy var regexQuery: Query? = {
-        return query(for: .regex)
+        return queryFor(.regex)
     }()
 
     /// Query for `Ruby` files.

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -64,6 +64,8 @@ public class TreeSitterModel {
             return phpQuery
         case .python:
             return pythonQuery
+        case .regex:
+            return regexQuery
         case .ruby:
             return rubyQuery
         case .rust:
@@ -189,6 +191,11 @@ public class TreeSitterModel {
     /// Query for `Python` files.
     public private(set) lazy var pythonQuery: Query? = {
         return queryFor(.python)
+    }()
+
+    /// Query for `Regex` files.
+    public private(set) lazy var regexQuery: Query? = {
+        return query(for: .regex)
     }()
 
     /// Query for `Ruby` files.


### PR DESCRIPTION
Adds support for the regex language. Regex doesn't have a standalone file type so the `extensions` array is left empty.

In action in CodeEdit *(CE doesn't syntax highlight any punctuation pairs but it shows the @ symbol and numbers being parsed)*:
<img width="492" alt="Screenshot 2023-03-15 at 11 43 16 PM" src="https://user-images.githubusercontent.com/35942988/225516541-aad02972-183c-4c37-9bd3-73f493ef040a.png">
