### PR TITLE
Update `tree-sitter-ocaml` Dependency to Official Repository (Resubmission)

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		6CA62EAB29F9D36700785B11 /* TreeSitterTSX in Frameworks */ = {isa = PBXBuildFile; productRef = 6CA62EAA29F9D36700785B11 /* TreeSitterTSX */; };
 		6CEC70FE29C3A85000B61C7A /* TreeSitterRegex in Frameworks */ = {isa = PBXBuildFile; productRef = 6CEC70FD29C3A85000B61C7A /* TreeSitterRegex */; };
 		7DB18E9729FDC51C00F8EC00 /* TreeSitterScala in Frameworks */ = {isa = PBXBuildFile; productRef = 7DB18E9629FDC51C00F8EC00 /* TreeSitterScala */; };
-		9D6DA3B8298F1A4600E69066 /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */; };
+		9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */; };
 		9DFDC3662A02D9BE0023B3BC /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +59,7 @@
 				285BF67329AAA45B00641989 /* TreeSitterLua in Frameworks */,
 				6CA62EAB29F9D36700785B11 /* TreeSitterTSX in Frameworks */,
 				2846B262296BA1CF005F60B6 /* TreeSitterDockerfile in Frameworks */,
+				9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */,
 				282C119329AA32C8004F1EA6 /* TreeSitterSQL in Frameworks */,
 				28B3F039290C362C000CD04D /* TreeSitterElixir in Frameworks */,
 				28B3F02D290C35D9000CD04D /* TreeSitterC in Frameworks */,
@@ -72,7 +73,6 @@
 				28B3F036290C361D000CD04D /* TreeSitterCSS in Frameworks */,
 				28B3F033290C3608000CD04D /* TreeSitterCSharp in Frameworks */,
 				28B3F03F290C364D000CD04D /* TreeSitterGoMod in Frameworks */,
-				9D6DA3B8298F1A4600E69066 /* TreeSitterOCaml in Frameworks */,
 				28B3F063290C372D000CD04D /* TreeSitterZig in Frameworks */,
 				28B3F045290C366E000CD04D /* TreeSitterHTML in Frameworks */,
 				28B3F05A290C36E5000CD04D /* TreeSitterRust in Frameworks */,
@@ -184,7 +184,6 @@
 				282E5976298051980064B34A /* TreeSitterYAML */,
 				2886C787298135540023E016 /* TreeSitterKotlin */,
 				28171CB729814CD800523F1C /* TreeSitterObjC */,
-				9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */,
 				282C119229AA32C8004F1EA6 /* TreeSitterSQL */,
 				285BF67229AAA45B00641989 /* TreeSitterLua */,
 				6CEC70FD29C3A85000B61C7A /* TreeSitterRegex */,
@@ -193,6 +192,7 @@
 				6CA62EAA29F9D36700785B11 /* TreeSitterTSX */,
 				7DB18E9629FDC51C00F8EC00 /* TreeSitterScala */,
 				9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */,
+				9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -246,7 +246,6 @@
 				282E5975298051980064B34A /* XCRemoteSwiftPackageReference "tree-sitter-yaml" */,
 				2886C786298135540023E016 /* XCRemoteSwiftPackageReference "tree-sitter-kotlin" */,
 				28171CB629814CD800523F1C /* XCRemoteSwiftPackageReference "tree-sitter-objc" */,
-				9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */,
 				282C119129AA32C8004F1EA6 /* XCRemoteSwiftPackageReference "tree-sitter-sql" */,
 				285BF67129AAA45B00641989 /* XCRemoteSwiftPackageReference "tree-sitter-lua" */,
 				6CEC70FC29C3A85000B61C7A /* XCRemoteSwiftPackageReference "tree-sitter-regex" */,
@@ -254,6 +253,7 @@
 				6CA62EA729F9D36700785B11 /* XCRemoteSwiftPackageReference "tree-sitter-typescript" */,
 				7DB18E9529FDC51C00F8EC00 /* XCRemoteSwiftPackageReference "tree-sitter-scala" */,
 				9DFDC3642A02D9BE0023B3BC /* XCRemoteSwiftPackageReference "tree-sitter-markdown" */,
+				9D6E744F2A2B9B2A0070701E /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -735,11 +735,11 @@
 				kind = branch;
 			};
 		};
-		9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */ = {
+		9D6E744F2A2B9B2A0070701E /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/cengelbart39/tree-sitter-ocaml.git";
+			repositoryURL = "https://github.com/tree-sitter/tree-sitter-ocaml.git";
 			requirement = {
-				branch = feature/spm;
+				branch = master;
 				kind = branch;
 			};
 		};
@@ -904,9 +904,9 @@
 			package = 7DB18E9529FDC51C00F8EC00 /* XCRemoteSwiftPackageReference "tree-sitter-scala" */;
 			productName = TreeSitterScala;
 		};
-		9D6DA3B7298F1A4600E69066 /* TreeSitterOCaml */ = {
+		9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 9D6DA3B6298F1A4500E69066 /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */;
+			package = 9D6E744F2A2B9B2A0070701E /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */;
 			productName = TreeSitterOCaml;
 		};
 		9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */ = {

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -183,10 +183,10 @@
     {
       "identity" : "tree-sitter-ocaml",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/cengelbart39/tree-sitter-ocaml.git",
+      "location" : "https://github.com/tree-sitter/tree-sitter-ocaml.git",
       "state" : {
-        "branch" : "feature/spm",
-        "revision" : "506d9a4a7709b3cb629e015476a8a640ac3c06ed"
+        "branch" : "master",
+        "revision" : "2da49308381b91e19e5d270ec5117616d0e4b135"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ In order to add support for additional languages we have a complete guide on how
 | [Julia](https://github.com/tree-sitter/tree-sitter-julia) |  | _not available_ |
 | [Kotlin](https://github.com/lukepistrol/tree-sitter-kotlin/tree/feature/spm-queries) | ✅ | ✅ |
 | [Lua](https://github.com/lukepistrol/tree-sitter-lua/tree/feature/spm) | ✅ | ✅ |
-| [Markdown](https://github.com/ikatyang/tree-sitter-markdown) |  | _not available_ |
+| [Markdown](https://github.com/MDeiml/tree-sitter-markdown) | ✅ | ✅ |
 | [Objective C](https://github.com/lukepistrol/tree-sitter-objc/tree/feature/spm) | ✅ | ✅ |
-| [OCaml](https://github.com/cengelbart39/tree-sitter-ocaml/tree/feature/spm) | ✅ | ✅ |
+| [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml) | ✅ | ✅ |
 | Plain Text | ✅ | _not available_ |
 | [Perl](https://github.com/ganezdragon/tree-sitter-perl) |  | _not available_ |
 | [PHP](https://github.com/tree-sitter/tree-sitter-php) | ✅ | ✅ |

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/highlights.scm
@@ -42,11 +42,11 @@
 
 (infix_expression
   left: (value_path (value_name) @function)
-  (infix_operator) @operator
+  operator: (concat_operator) @operator
   (#eq? @operator "@@"))
 
 (infix_expression
-  (infix_operator) @operator
+  operator: (rel_operator) @operator
   right: (value_path (value_name) @function)
   (#eq? @operator "|>"))
 
@@ -85,21 +85,25 @@
 
 (match_expression (match_operator) @keyword)
 
-(value_definition [(let_operator) (and_operator)] @keyword)
+(value_definition [(let_operator) (let_and_operator)] @keyword)
 
 [
   (prefix_operator)
   (sign_operator)
-  (infix_operator)
+  (pow_operator)
+  (mult_operator)
+  (add_operator)
+  (concat_operator)
+  (rel_operator)
+  (and_operator)
+  (or_operator)
+  (assign_operator)
   (hash_operator)
   (indexing_operator)
   (let_operator)
-  (and_operator)
+  (let_and_operator)
   (match_operator)
 ] @operator
-
-(infix_operator ["&" "+" "-" "=" ">" "|" "%"] @operator)
-(signed_number ["+" "-"] @operator)
 
 ["*" "#" "::" "<-"] @operator
 

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/tags.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/tags.scm
@@ -49,11 +49,11 @@
 
 (infix_expression
   left: (value_path (value_name) @name)
-  (infix_operator) @reference.call
+  operator: (concat_operator) @reference.call
   (#eq? @reference.call "@@"))
 
 (infix_expression
-  (infix_operator) @reference.call
+  operator: (rel_operator) @reference.call
   right: (value_path (value_name) @name)
   (#eq? @reference.call "|>"))
 
@@ -64,26 +64,25 @@
   (comment)? @doc .
   (value_definition
     (let_binding
-      pattern: (parenthesized_operator [
-        (prefix_operator)
-        (infix_operator)
-        (hash_operator)
-        (indexing_operator)
-        (let_operator)
-        (and_operator)
-        (match_operator)
-      ] @name)) @definition.function)
+      pattern: (parenthesized_operator (_) @name)) @definition.function)
   (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
 )
 
 [
   (prefix_operator)
   (sign_operator)
-  (infix_operator)
+  (pow_operator)
+  (mult_operator)
+  (add_operator)
+  (concat_operator)
+  (rel_operator)
+  (and_operator)
+  (or_operator)
+  (assign_operator)
   (hash_operator)
   (indexing_operator)
   (let_operator)
-  (and_operator)
+  (let_and_operator)
   (match_operator)
 ] @name @reference.call
 

--- a/build_framework.sh
+++ b/build_framework.sh
@@ -88,10 +88,10 @@ for lang in $LIST ; do
     manifest=$(swift package dump-package)
 
     # use jq to get the target path
-    targets=$(echo $manifest | jq -r '.targets[].path')
+    targets=$(echo $manifest | jq -r '.targets[] | select(.type != "test") | .path')
     
     # use jq to count number of targets
-    count=$(echo $manifest | jq '.targets | length')
+    count=$(echo $manifest | jq '[.targets[] | select(.type != "test")] | length')
     
     # Determine if target paths are all '.'
     same=1


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Resubmission of #43 following merge conflicts created by #42.

Original Description:
> PR #24 added support for OCaml via a fork I created.
> 
> Since then, the [official repository](https://github.com/tree-sitter/tree-sitter-ocaml) has been updated with SPM support. This PR switches the `tree-sitter-ocaml` dependency to the official repository.
> 
> Additionally, minor changes were made to the build script to ignore test targets, which `tree-sitter-ocaml` has.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #42 
* #43

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
