### PR TITLE
Shebang and Modeline Detection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "CodeEditLanguages",
-    platforms: [.macOS(.v12)],
+    platforms: [.macOS(.v13)],
     products: [
         .library(
             name: "CodeEditLanguages",

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -148,7 +148,8 @@ public extension CodeLanguage {
         id: .javascript,
         tsName: "javascript",
         extensions: ["js"],
-        highlights: ["injections"]
+        highlights: ["injections"],
+        additionalIdentifiers: ["node", "deno"]
     )
 
     /// A language structure for `JSON`
@@ -230,7 +231,8 @@ public extension CodeLanguage {
     static let python: CodeLanguage = .init(
         id: .python,
         tsName: "python",
-        extensions: ["py"]
+        extensions: ["py"],
+        additionalIdentifiers: ["python2", "python3"]
     )
 
     /// A language structure for `Regex`

--- a/Sources/CodeEditLanguages/CodeLanguage+DetectLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+DetectLanguage.swift
@@ -1,0 +1,204 @@
+//
+//  CodeLanguage+DetectLanguage.swift
+//  CodeEditLanguages
+//
+//  Created by Khan Winter on 6/17/23.
+//
+
+import Foundation
+import RegexBuilder
+
+public extension CodeLanguage {
+
+    /// Gets the corresponding language for the given file URL
+    ///
+    /// Uses the `pathExtension` URL component to detect the language
+    /// - Returns: A language structure
+    /// - Parameters:
+    ///   - url: The URL to get the language for.
+    ///   - prefixBuffer: The first few lines of the document.
+    ///   - suffixBuffer: The last few lines of the document.
+    static func detectLanguageFrom(url: URL, prefixBuffer: String? = nil, suffixBuffer: String? = nil) -> CodeLanguage {
+        if let urlLanguage = detectLanguageUsingURL(url: url) {
+            return urlLanguage
+        } else if let prefixBuffer,
+                  let shebangLanguage = detectLanguageUsingShebang(contents: prefixBuffer.lowercased()) {
+            return shebangLanguage
+        } else if let prefixBuffer,
+                  let modelineLanguage = detecLanguageUsingModeline(
+                    prefixBuffer: prefixBuffer.lowercased(),
+                    suffixBuffer: suffixBuffer?.lowercased()
+                  ) {
+            return modelineLanguage
+        } else {
+            return .default
+        }
+    }
+
+    /// Detects a file's language using the file url.
+    /// - Parameter url: The URL of the file.
+    /// - Returns: The detected code language, if any.
+    private static func detectLanguageUsingURL(url: URL) -> CodeLanguage? {
+        let fileExtension = url.pathExtension.lowercased()
+        let fileName = url.pathComponents.last // should not be lowercase since it has to match e.g. `Dockerfile`
+        // This is to handle special file types without an extension (e.g., Makefile, Dockerfile)
+        let fileNameOrExtension = fileExtension.isEmpty ? (fileName != nil ? fileName! : "") : fileExtension
+        if let lang = allLanguages.first(where: { lang in lang.extensions.contains(fileNameOrExtension)}) {
+            return lang
+        } else {
+            return nil
+        }
+    }
+
+    /// Detects code langauges from the shebang of a file.
+    /// Eg: `#!/usr/bin/env/python2.6` will detect the `python` code language.
+    /// Or, `#! /usr/bin/env perl` will detect the `perl` code language.
+    /// - Parameter contents: The contents of the first few lines of the file.
+    /// - Returns: The detected code language, if any.
+    private static func detectLanguageUsingShebang(contents: String) -> CodeLanguage? {
+        var contents = contents
+        // Make sure:
+        // - First line is a shebang
+        // - There are contents after the shebang
+        // - There is a valid script component (eg: "swift" in "/usr/env/swift")
+        guard
+            contents.starts(with: "#!"),
+            contents.trimmingCharacters(in: .whitespacesAndNewlines) != "#!",
+            let result = contents
+                .split(separator: "/", omittingEmptySubsequences: true)
+                .last?
+                .firstMatch(of: Regex { OneOrMore(.word) })
+        else {
+            return nil
+        }
+
+        var script = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // If script is "env" walk the string until we find a valid-looking script component
+        if script == "env" {
+            // If env is the end of the string, return
+            guard result.endIndex != contents.endIndex else { return nil }
+
+            let argumentRegex = Regex {
+                ZeroOrMore(.whitespace)
+                ChoiceOf {
+                    One("-")
+                    One("--")
+                }
+                ZeroOrMore(.word)
+                ZeroOrMore(.whitespace)
+            }
+            let parameterRegex = Regex {
+                OneOrMore(.word)
+                One("=")
+                OneOrMore(.word)
+            }
+
+            // Skip over any optional arguments or parameters (eg: -x or x=y) and make script the next valid string
+            // https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html
+            // Skip first shebang-path string
+            contents.trimPrefix(Regex {
+                OneOrMore("#!")
+                ZeroOrMore(.whitespace)
+                OneOrMore(.any, .reluctant)
+                OneOrMore(.whitespace)
+            })
+            while !contents.isEmpty {
+                if contents.prefixMatch(of: argumentRegex) != nil {
+                    contents.trimPrefix(argumentRegex)
+                } else if  contents.prefixMatch(of: parameterRegex) != nil {
+                    contents.trimPrefix(parameterRegex)
+                } else {
+                    break
+                }
+            }
+            guard let newScript = contents.firstMatch(of: Regex { OneOrMore(.word) })?.output else {
+                return nil
+            }
+            script = String(newScript)
+        }
+
+        return languageFromIdentifier(script)
+    }
+
+    /// Detects modelines in either the beginning or end of a file.
+    ///
+    /// Examples of valid modelines:
+    /// ```
+    /// # vim: set ft=js ts=4 sw=4 et:
+    /// # vim: ts=4:sw=4:et:ft=js
+    /// -*- mode: js; indent-tabs-mode: nil; tab-width: 4 -*-
+    /// code: language=javascript insertSpaces=true tabSize=4
+    /// ```
+    /// All of the above would resolve to `javascript`
+    ///
+    /// - Parameters:
+    ///   - prefixBuffer: The first few lines of a document.
+    ///   - suffixBuffer: The last few lines of a document.
+    /// - Returns: The detected code language, if any.
+    private static func detecLanguageUsingModeline(prefixBuffer: String, suffixBuffer: String?) -> CodeLanguage? {
+        func detectModeline(in string: String) -> CodeLanguage? {
+            guard !string.isEmpty else { return nil }
+
+            // Regex for detecting emacs modelines.
+            let emacsLineRegex =  Regex {
+                "-*-"
+                Capture {
+                    #/.*/#
+                }
+                "-*-"
+            }
+
+            // Regex to find language parameters in a emacs modeline.
+            let emacsLanguageRegex = Regex {
+                "mode:"
+                ZeroOrMore(.whitespace)
+                Capture {
+                    OneOrMore(.word)
+                }
+            }
+
+            // Regex for detecting vim modelines.
+            let vimLineRegex = Regex {
+                ChoiceOf {
+                    One("//")
+                    One("/*")
+                }
+                OneOrMore(.whitespace)
+                #/vim:.*/#
+                Optionally(.newlineSequence)
+            }
+
+            // Regex to find language parameters in a vim modeline.
+            let vimLanguageRegex = Regex {
+                "ft="
+                Capture {
+                    OneOrMore(.word)
+                }
+            }
+
+            if let emacsLine = string.firstMatch(of: emacsLineRegex)?.1,
+               let emacsLanguage = emacsLine.firstMatch(of: emacsLanguageRegex)?.1 {
+                return languageFromIdentifier(String(emacsLanguage))
+            } else if let vimLine = string.firstMatch(of: vimLineRegex)?.0,
+                      let vimLanguage = vimLine.firstMatch(of: vimLanguageRegex)?.1 {
+                return languageFromIdentifier(String(vimLanguage))
+            } else {
+                return nil
+            }
+        }
+
+        return detectModeline(in: prefixBuffer) ?? detectModeline(in: suffixBuffer ?? "")
+    }
+
+    /// Finds a language to match a parsed identifier.
+    /// - Parameter identifier: The identifier to use.
+    /// - Returns: The found code language, if any.
+    private static func languageFromIdentifier(_ identifier: String) -> CodeLanguage? {
+        return allLanguages.first {
+            $0.tsName == identifier
+            || $0.extensions.contains(identifier)
+            || $0.additionalIdentifiers.contains(identifier)
+        }
+    }
+}

--- a/Sources/CodeEditLanguages/CodeLanguage+DetectLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+DetectLanguage.swift
@@ -56,7 +56,7 @@ public extension CodeLanguage {
     /// - Parameter contents: The contents of the first few lines of the file.
     /// - Returns: The detected code language, if any.
     private static func detectLanguageUsingShebang(contents: String) -> CodeLanguage? {
-        var contents = contents
+        var contents = String(contents.split(separator: "\n").first ?? "")
         // Make sure:
         // - First line is a shebang
         // - There are contents after the shebang

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -9,6 +9,7 @@ import Foundation
 import tree_sitter
 import SwiftTreeSitter
 import CodeLanguages_Container
+import RegexBuilder
 
 /// A structure holding metadata for code languages
 public struct CodeLanguage {
@@ -17,13 +18,15 @@ public struct CodeLanguage {
         tsName: String,
         extensions: Set<String>,
         parentURL: URL? = nil,
-        highlights: Set<String>? = nil
+        highlights: Set<String>? = nil,
+        additionalIdentifiers: Set<String> = []
     ) {
         self.id = id
         self.tsName = tsName
         self.extensions = extensions
         self.parentQueryURL = parentURL
         self.additionalHighlights = highlights
+        self.additionalIdentifiers = additionalIdentifiers
     }
 
     /// The ID of the language
@@ -51,6 +54,9 @@ public struct CodeLanguage {
 
     /// The bundle's resource URL
     internal var resourceURL: URL? = Bundle.module.resourceURL
+
+    /// A set of aditional identifiers to use for things like shebang matching.
+    public let additionalIdentifiers: Set<String>
 
     /// The tree-sitter language for the language if available
     public var language: Language? {
@@ -142,22 +148,8 @@ public struct CodeLanguage {
     }
 }
 
-public extension CodeLanguage {
-
-    /// Gets the corresponding language for the given file URL
-    ///
-    /// Uses the `pathExtension` URL component to detect the language
-    /// - Parameter url: The URL to get the language for.
-    /// - Returns: A language structure
-    static func detectLanguageFrom(url: URL) -> CodeLanguage {
-        let fileExtension = url.pathExtension.lowercased()
-        let fileName = url.pathComponents.last // should not be lowercase since it has to match e.g. `Dockerfile`
-        // This is to handle special file types without an extension (e.g., Makefile, Dockerfile)
-        let fileNameOrExtension = fileExtension.isEmpty ? (fileName != nil ? fileName! : "") : fileExtension
-        if let lang = allLanguages.first(where: { lang in lang.extensions.contains(fileNameOrExtension)}) {
-            return lang
-        } else {
-            return .default
-        }
+extension CodeLanguage: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/Tests/CodeEditLanguagesTests/LanguageDetectionTests.swift
+++ b/Tests/CodeEditLanguagesTests/LanguageDetectionTests.swift
@@ -1,0 +1,125 @@
+//
+//  LanguageDetectionTests.swift
+//  CodeEditLanguages
+//
+//  Created by Khan Winter on 6/17/23.
+//
+
+import XCTest
+@testable import CodeEditLanguages
+import RegexBuilder
+
+// swiftlint:disable all
+final class LanguageDetectionTests: XCTestCase {
+    func test_shebang() {
+        let validCases = [
+            "#! /usr/bin/env swift",
+            "#! /usr/bin/env -S swift",
+            "#!/usr/bin/env swift",
+            "#!     /usr/bin/env         swift",
+            "#! swift",
+            "#!swift"
+        ]
+
+        let invalidCases = [
+            "1234",
+            "import CodeEditLanguages",
+            "",
+            "\n",
+            "# This is a regular comment",
+            "#!",
+            "#",
+            "!"
+        ]
+
+        for validCase in validCases {
+            let detectedLanguage = CodeLanguage.detectLanguageFrom(url: URL(filePath: ""), prefixBuffer: validCase)
+            XCTAssert(
+                detectedLanguage == .swift,
+                "Parser failed to find valid shebang language. Given \"\(validCase)\", found \(detectedLanguage), expected swift."
+            )
+        }
+
+        for invalidCase in invalidCases {
+            let detectedLanguage = CodeLanguage.detectLanguageFrom(url: URL(filePath: ""), prefixBuffer: invalidCase)
+            XCTAssert(
+                detectedLanguage == .default,
+                "Parser unexpectedly found valid shebang language. Given \"\(invalidCase)\", found \(detectedLanguage), expected default."
+            )
+        }
+    }
+
+    func test_vimModeline() {
+        let validCases = [
+            "// vim: ft=swift",
+            "/* vim: ft=swift */",
+            "/* vim: other=param a=b ft=swift b=d\n*/",
+            "// vim: other=param a=b ft=swift b=d",
+        ]
+
+        let invalidCases = [
+            "//vim:",
+            "//vim",
+            "// This is a normal comment",
+            "/*vim",
+            "/* vim",
+            "/* this is also a normal comment */",
+            "1234",
+            "import CodeEditLanguages",
+            "",
+            "\n"
+        ]
+
+        for validCase in validCases {
+            let detectedLanguage = CodeLanguage.detectLanguageFrom(url: URL(filePath: ""), prefixBuffer: validCase)
+            XCTAssert(
+                detectedLanguage == .swift,
+                "Parser failed to find valid shebang language. Given \"\(validCase)\", found \(detectedLanguage), expected swift."
+            )
+        }
+
+        for invalidCase in invalidCases {
+            let detectedLanguage = CodeLanguage.detectLanguageFrom(url: URL(filePath: ""), prefixBuffer: invalidCase)
+            XCTAssert(
+                detectedLanguage == .default,
+                "Parser unexpectedly found valid shebang language. Given \"\(invalidCase)\", found \(detectedLanguage), expected default."
+            )
+        }
+    }
+
+    func test_emacsModeline() {
+        let validCases = [
+            "-*- mode:swift -*-",
+            "-*- indent-style: tabs mode: swift -*-",
+            "-*-mode: swift-*-"
+        ]
+
+        let invalidCases = [
+            "1234",
+            "import CodeEditLanguages",
+            "",
+            "\n",
+            "-*-",
+            "-*- -*-",
+            "-- -*-",
+            "mode:swift"
+        ]
+
+        for validCase in validCases {
+            let detectedLanguage = CodeLanguage.detectLanguageFrom(url: URL(filePath: ""), prefixBuffer: validCase)
+            XCTAssert(
+                detectedLanguage == .swift,
+                "Parser failed to find valid shebang language. Given \"\(validCase)\", found \(detectedLanguage), expected swift."
+            )
+        }
+
+        for invalidCase in invalidCases {
+            let detectedLanguage = CodeLanguage.detectLanguageFrom(url: URL(filePath: ""), prefixBuffer: invalidCase)
+            XCTAssert(
+                detectedLanguage == .default,
+                "Parser unexpectedly found valid shebang language. Given \"\(invalidCase)\", found \(detectedLanguage), expected default."
+            )
+        }
+    }
+}
+// swiftlint:enable all


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds shebang and mode line detection to the `CodeLanguage.detectLanguage` function.

Shebangs are commonly used in scripting languages like python or ruby to allow the scripts to be run by the operating system by adding a "#! ..." line at the top of the file.

modelines are used by Emacs and Vim to configure editor functionality. Both have parameters for setting the file type.

`CodeLanguage.detectLanguage` can now detect both shebangs and modelines via the optional parameters `prefixBuffer` and `suffixBuffer`. It will check the prefix buffer for a valid shebang, and if found attempt to parse it. If no shebang is found, it will attempt to find and parse a valid modeline from either the prefix or suffix (Emacs modelines can be in the first or last 5 lines of the file).

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #46 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Once the changes are propagated to CodeEditTextView and CodeEdit, opened files can detect shebangs and modelines:

Python detection:
<img width="282" alt="Screenshot 2023-06-17 at 6 21 19 PM" src="https://github.com/CodeEditApp/CodeEditLanguages/assets/35942988/b343b9c7-c913-4f40-887d-5b737ff79bd2">

Vim modeline detecting javascript:
<img width="338" alt="Screenshot 2023-06-17 at 6 21 34 PM" src="https://github.com/CodeEditApp/CodeEditLanguages/assets/35942988/2936a4d0-2273-4761-a9ff-b3b31e1cdcef">

Node:
<img width="232" alt="Screenshot 2023-06-17 at 7 23 39 PM" src="https://github.com/CodeEditApp/CodeEditLanguages/assets/35942988/935113ac-0e0b-457f-a48c-28781bbbed18">

