### PR TITLE
Add `Agda`, `Julia`, `Perl`, and `Verilog` Grammars

### DIFF
--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		9D7399242A5A245000CEF6E8 /* TreeSitterAgda in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399232A5A245000CEF6E8 /* TreeSitterAgda */; };
 		9D7399272A5A2B5300CEF6E8 /* TreeSitterJulia in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */; };
 		9D73992A2A5A30A400CEF6E8 /* TreeSitterPerl in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399292A5A30A400CEF6E8 /* TreeSitterPerl */; };
+		9D73992D2A5A34BF00CEF6E8 /* TreeSitterVerilog in Frameworks */ = {isa = PBXBuildFile; productRef = 9D73992C2A5A34BF00CEF6E8 /* TreeSitterVerilog */; };
 		9DB1B4362A2C0DAA0027B04E /* TreeSitterJSDoc in Frameworks */ = {isa = PBXBuildFile; productRef = 9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */; };
 		9DFDC3662A02D9BE0023B3BC /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */; };
 /* End PBXBuildFile section */
@@ -68,6 +69,7 @@
 				9D73992A2A5A30A400CEF6E8 /* TreeSitterPerl in Frameworks */,
 				9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */,
 				282C119329AA32C8004F1EA6 /* TreeSitterSQL in Frameworks */,
+				9D73992D2A5A34BF00CEF6E8 /* TreeSitterVerilog in Frameworks */,
 				28B3F039290C362C000CD04D /* TreeSitterElixir in Frameworks */,
 				28B3F02D290C35D9000CD04D /* TreeSitterC in Frameworks */,
 				28B3F04B290C368B000CD04D /* TreeSitterJS in Frameworks */,
@@ -208,6 +210,7 @@
 				9D7399232A5A245000CEF6E8 /* TreeSitterAgda */,
 				9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */,
 				9D7399292A5A30A400CEF6E8 /* TreeSitterPerl */,
+				9D73992C2A5A34BF00CEF6E8 /* TreeSitterVerilog */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -274,6 +277,7 @@
 				9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */,
 				9D7399252A5A2B5200CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-julia" */,
 				9D7399282A5A30A400CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-perl" */,
+				9D73992B2A5A34BF00CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-verilog" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -795,6 +799,14 @@
 				kind = branch;
 			};
 		};
+		9D73992B2A5A34BF00CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-verilog" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tree-sitter/tree-sitter-verilog.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		9DB1B4342A2C0DA90027B04E /* XCRemoteSwiftPackageReference "tree-sitter-jsdoc" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cengelbart39/tree-sitter-jsdoc.git";
@@ -988,6 +1000,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9D7399282A5A30A400CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-perl" */;
 			productName = TreeSitterPerl;
+		};
+		9D73992C2A5A34BF00CEF6E8 /* TreeSitterVerilog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9D73992B2A5A34BF00CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-verilog" */;
+			productName = TreeSitterVerilog;
 		};
 		9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		9D0F66222A3F522700E0F4B7 /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 9D0F66212A3F522700E0F4B7 /* TreeSitterTOML */; };
 		9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */; };
 		9D7399242A5A245000CEF6E8 /* TreeSitterAgda in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399232A5A245000CEF6E8 /* TreeSitterAgda */; };
+		9D7399272A5A2B5300CEF6E8 /* TreeSitterJulia in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */; };
 		9DB1B4362A2C0DAA0027B04E /* TreeSitterJSDoc in Frameworks */ = {isa = PBXBuildFile; productRef = 9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */; };
 		9DFDC3662A02D9BE0023B3BC /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */; };
 /* End PBXBuildFile section */
@@ -79,6 +80,7 @@
 				28B3F033290C3608000CD04D /* TreeSitterCSharp in Frameworks */,
 				28B3F03F290C364D000CD04D /* TreeSitterGoMod in Frameworks */,
 				28B3F063290C372D000CD04D /* TreeSitterZig in Frameworks */,
+				9D7399272A5A2B5300CEF6E8 /* TreeSitterJulia in Frameworks */,
 				28B3F045290C366E000CD04D /* TreeSitterHTML in Frameworks */,
 				28B3F05A290C36E5000CD04D /* TreeSitterRust in Frameworks */,
 				28AAB6AE29CA57D40087654B /* TreeSitterDart in Frameworks */,
@@ -202,6 +204,7 @@
 				9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */,
 				9D0F66212A3F522700E0F4B7 /* TreeSitterTOML */,
 				9D7399232A5A245000CEF6E8 /* TreeSitterAgda */,
+				9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -266,6 +269,7 @@
 				9DB1B4342A2C0DA90027B04E /* XCRemoteSwiftPackageReference "tree-sitter-jsdoc" */,
 				9D0F66202A3F522700E0F4B7 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
 				9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */,
+				9D7399252A5A2B5200CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-julia" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -771,6 +775,14 @@
 				kind = branch;
 			};
 		};
+		9D7399252A5A2B5200CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-julia" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tree-sitter/tree-sitter-julia.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		9DB1B4342A2C0DA90027B04E /* XCRemoteSwiftPackageReference "tree-sitter-jsdoc" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cengelbart39/tree-sitter-jsdoc.git";
@@ -954,6 +966,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */;
 			productName = TreeSitterAgda;
+		};
+		9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9D7399252A5A2B5200CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-julia" */;
+			productName = TreeSitterJulia;
 		};
 		9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */; };
 		9D7399242A5A245000CEF6E8 /* TreeSitterAgda in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399232A5A245000CEF6E8 /* TreeSitterAgda */; };
 		9D7399272A5A2B5300CEF6E8 /* TreeSitterJulia in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */; };
+		9D73992A2A5A30A400CEF6E8 /* TreeSitterPerl in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399292A5A30A400CEF6E8 /* TreeSitterPerl */; };
 		9DB1B4362A2C0DAA0027B04E /* TreeSitterJSDoc in Frameworks */ = {isa = PBXBuildFile; productRef = 9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */; };
 		9DFDC3662A02D9BE0023B3BC /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */; };
 /* End PBXBuildFile section */
@@ -64,6 +65,7 @@
 				6CA62EAB29F9D36700785B11 /* TreeSitterTSX in Frameworks */,
 				9DB1B4362A2C0DAA0027B04E /* TreeSitterJSDoc in Frameworks */,
 				2846B262296BA1CF005F60B6 /* TreeSitterDockerfile in Frameworks */,
+				9D73992A2A5A30A400CEF6E8 /* TreeSitterPerl in Frameworks */,
 				9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */,
 				282C119329AA32C8004F1EA6 /* TreeSitterSQL in Frameworks */,
 				28B3F039290C362C000CD04D /* TreeSitterElixir in Frameworks */,
@@ -205,6 +207,7 @@
 				9D0F66212A3F522700E0F4B7 /* TreeSitterTOML */,
 				9D7399232A5A245000CEF6E8 /* TreeSitterAgda */,
 				9D7399262A5A2B5300CEF6E8 /* TreeSitterJulia */,
+				9D7399292A5A30A400CEF6E8 /* TreeSitterPerl */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -270,6 +273,7 @@
 				9D0F66202A3F522700E0F4B7 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
 				9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */,
 				9D7399252A5A2B5200CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-julia" */,
+				9D7399282A5A30A400CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-perl" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -783,6 +787,14 @@
 				kind = branch;
 			};
 		};
+		9D7399282A5A30A400CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-perl" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ganezdragon/tree-sitter-perl.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		9DB1B4342A2C0DA90027B04E /* XCRemoteSwiftPackageReference "tree-sitter-jsdoc" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cengelbart39/tree-sitter-jsdoc.git";
@@ -971,6 +983,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9D7399252A5A2B5200CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-julia" */;
 			productName = TreeSitterJulia;
+		};
+		9D7399292A5A30A400CEF6E8 /* TreeSitterPerl */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9D7399282A5A30A400CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-perl" */;
+			productName = TreeSitterPerl;
 		};
 		9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		7DB18E9729FDC51C00F8EC00 /* TreeSitterScala in Frameworks */ = {isa = PBXBuildFile; productRef = 7DB18E9629FDC51C00F8EC00 /* TreeSitterScala */; };
 		9D0F66222A3F522700E0F4B7 /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 9D0F66212A3F522700E0F4B7 /* TreeSitterTOML */; };
 		9D6E74512A2B9B2A0070701E /* TreeSitterOCaml in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */; };
+		9D7399242A5A245000CEF6E8 /* TreeSitterAgda in Frameworks */ = {isa = PBXBuildFile; productRef = 9D7399232A5A245000CEF6E8 /* TreeSitterAgda */; };
 		9DB1B4362A2C0DAA0027B04E /* TreeSitterJSDoc in Frameworks */ = {isa = PBXBuildFile; productRef = 9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */; };
 		9DFDC3662A02D9BE0023B3BC /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9DFDC3652A02D9BE0023B3BC /* TreeSitterMarkdown */; };
 /* End PBXBuildFile section */
@@ -87,6 +88,7 @@
 				6CEC70FE29C3A85000B61C7A /* TreeSitterRegex in Frameworks */,
 				282E5977298051980064B34A /* TreeSitterYAML in Frameworks */,
 				6CA62EA929F9D36700785B11 /* TreeSitterTS in Frameworks */,
+				9D7399242A5A245000CEF6E8 /* TreeSitterAgda in Frameworks */,
 				2886C788298135540023E016 /* TreeSitterKotlin in Frameworks */,
 				28B3F057290C36D5000CD04D /* TreeSitterRuby in Frameworks */,
 			);
@@ -199,6 +201,7 @@
 				9D6E74502A2B9B2A0070701E /* TreeSitterOCaml */,
 				9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */,
 				9D0F66212A3F522700E0F4B7 /* TreeSitterTOML */,
+				9D7399232A5A245000CEF6E8 /* TreeSitterAgda */,
 			);
 			productName = "CodeLanguages-Container";
 			productReference = 28B3F00C290C207D000CD04D /* CodeLanguages_Container.framework */;
@@ -262,6 +265,7 @@
 				9D6E744F2A2B9B2A0070701E /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */,
 				9DB1B4342A2C0DA90027B04E /* XCRemoteSwiftPackageReference "tree-sitter-jsdoc" */,
 				9D0F66202A3F522700E0F4B7 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
+				9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */,
 			);
 			productRefGroup = 28B3F00D290C207D000CD04D /* Products */;
 			projectDirPath = "";
@@ -759,6 +763,14 @@
 				kind = branch;
 			};
 		};
+		9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/cengelbart39/tree-sitter-agda.git";
+			requirement = {
+				branch = feat/spm;
+				kind = branch;
+			};
+		};
 		9DB1B4342A2C0DA90027B04E /* XCRemoteSwiftPackageReference "tree-sitter-jsdoc" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cengelbart39/tree-sitter-jsdoc.git";
@@ -937,6 +949,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9D6E744F2A2B9B2A0070701E /* XCRemoteSwiftPackageReference "tree-sitter-ocaml" */;
 			productName = TreeSitterOCaml;
+		};
+		9D7399232A5A245000CEF6E8 /* TreeSitterAgda */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9D7399222A5A245000CEF6E8 /* XCRemoteSwiftPackageReference "tree-sitter-agda" */;
+			productName = TreeSitterAgda;
 		};
 		9DB1B4352A2C0DAA0027B04E /* TreeSitterJSDoc */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -217,6 +217,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-perl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ganezdragon/tree-sitter-perl.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "60aa138f9e1db15becad53070f4d5898b0e8a98c"
+      }
+    },
+    {
       "identity" : "tree-sitter-php",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tree-sitter/tree-sitter-php.git",

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -316,6 +316,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-verilog",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-verilog.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "22f9b845c77c52b86b21adaebe689864957f4e31"
+      }
+    },
+    {
       "identity" : "tree-sitter-yaml",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/tree-sitter-yaml.git",

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -163,6 +163,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-julia",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-julia.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "784364cb9185ef8dc245de4b0b51e3a22503419d"
+      }
+    },
+    {
       "identity" : "tree-sitter-kotlin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/tree-sitter-kotlin",

--- a/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeLanguages-Container/CodeLanguages-Container.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-agda",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cengelbart39/tree-sitter-agda.git",
+      "state" : {
+        "branch" : "feat/spm",
+        "revision" : "076e015d084867a3f367fce3c23dee09fb666eb2"
+      }
+    },
+    {
       "identity" : "tree-sitter-bash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tree-sitter/tree-sitter-bash.git",

--- a/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
+++ b/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
@@ -39,6 +39,7 @@ extern TSLanguage *tree_sitter_java();
 extern TSLanguage *tree_sitter_javascript();
 extern TSLanguage *tree_sitter_jsdoc();
 extern TSLanguage *tree_sitter_json();
+extern TSLanguage *tree_sitter_julia();
 extern TSLanguage *tree_sitter_kotlin();
 extern TSLanguage *tree_sitter_lua();
 extern TSLanguage *tree_sitter_markdown();

--- a/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
+++ b/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
@@ -22,6 +22,7 @@ extern "C" {
 // A collection of pointers to supported tree-sitter languages
 // Add new ones below (please keep an alphabetical order)
 
+extern TSLanguage *tree_sitter_agda();
 extern TSLanguage *tree_sitter_bash();
 extern TSLanguage *tree_sitter_c();
 extern TSLanguage *tree_sitter_cpp();

--- a/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
+++ b/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
@@ -47,6 +47,7 @@ extern TSLanguage *tree_sitter_markdown_inline();
 extern TSLanguage *tree_sitter_objc();
 extern TSLanguage *tree_sitter_ocaml();
 extern TSLanguage *tree_sitter_ocaml_interface();
+extern TSLanguage *tree_sitter_perl();
 extern TSLanguage *tree_sitter_php();
 extern TSLanguage *tree_sitter_python();
 extern TSLanguage *tree_sitter_regex();

--- a/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
+++ b/CodeLanguages-Container/CodeLanguages-Container/CodeLanguages_Container.h
@@ -59,6 +59,7 @@ extern TSLanguage *tree_sitter_swift();
 extern TSLanguage *tree_sitter_toml();
 extern TSLanguage *tree_sitter_tsx();
 extern TSLanguage *tree_sitter_typescript();
+extern TSLanguage *tree_sitter_verilog();
 extern TSLanguage *tree_sitter_yaml();
 extern TSLanguage *tree_sitter_zig();
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In order to add support for additional languages we have a complete guide on how
 | [Java](https://github.com/tree-sitter/tree-sitter-java) | ✅ | ✅ |
 | [JavaScript/JSX](https://github.com/tree-sitter/tree-sitter-javascript) | ✅ | ✅ |
 | [JSDoc](https://github.com/cengelbart39/tree-sitter-jsdoc/tree/feature/spm) | ✅ | ✅ |
-| [JSON](https://github.com/mattmassicotte/tree-sitter-json) | ✅ | ✅ |
+| [JSON](https://github.com/tree-sitter/tree-sitter-json) | ✅ | ✅ |
 | [Julia](https://github.com/tree-sitter/tree-sitter-julia) | ✅ | _not available_ |
 | [JSON](https://github.com/tree-sitter/tree-sitter-json) | ✅ | ✅ |
 | [Julia](https://github.com/tree-sitter/tree-sitter-julia) | ✅  | _not available_ |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ In order to add support for additional languages we have a complete guide on how
 | [JSON](https://github.com/tree-sitter/tree-sitter-json) | ✅ | ✅ |
 | [Julia](https://github.com/tree-sitter/tree-sitter-julia) | ✅ | _not available_ |
 | [JSON](https://github.com/tree-sitter/tree-sitter-json) | ✅ | ✅ |
-| [Julia](https://github.com/tree-sitter/tree-sitter-julia) | ✅  | _not available_ |
 | [Kotlin](https://github.com/lukepistrol/tree-sitter-kotlin/tree/feature/spm-queries) | ✅ | ✅ |
 | [Lua](https://github.com/lukepistrol/tree-sitter-lua/tree/feature/spm) | ✅ | ✅ |
 | [Markdown](https://github.com/MDeiml/tree-sitter-markdown) | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In order to add support for additional languages we have a complete guide on how
 | [Objective C](https://github.com/lukepistrol/tree-sitter-objc/tree/feature/spm) | ✅ | ✅ |
 | [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml) | ✅ | ✅ |
 | Plain Text | ✅ | _not available_ |
-| [Perl](https://github.com/ganezdragon/tree-sitter-perl) |  | _not available_ |
+| [Perl](https://github.com/ganezdragon/tree-sitter-perl) | ✅ | _not available_ |
 | [PHP](https://github.com/tree-sitter/tree-sitter-php) | ✅ | ✅ |
 | [Python](https://github.com/lukepistrol/tree-sitter-python) | ✅ | ✅ |
 | [Regex](https://github.com/tree-sitter/tree-sitter-regex) | ✅ | ✅ |
@@ -82,7 +82,7 @@ In order to add support for additional languages we have a complete guide on how
 | [Swift](https://github.com/alex-pinkus/tree-sitter-swift/tree/with-generated-files) | ✅ | ✅ |
 | [TOML](https://github.com/cengelbart39/tree-sitter-toml/tree/feature/spm) | ✅ | ✅ |
 | [TypeScript/TSX](https://github.com/tree-sitter/tree-sitter-typescript) | ✅ | ✅ |
-| [Verilog](https://github.com/tree-sitter/tree-sitter-verilog) |  | _not available_ |
+| [Verilog](https://github.com/tree-sitter/tree-sitter-verilog) | ✅ | _not available_ |
 | [YAML](https://github.com/lukepistrol/tree-sitter-yaml/tree/feature/spm) | ✅ | ✅ |
 | [Zig](https://github.com/maxxnino/tree-sitter-zig) | ✅ | ✅ |
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In order to add support for additional languages we have a complete guide on how
 
 | Grammar        | Implemented | Syntax Highlighting |
 | -------------- | :---------: | :-----------------: |
-| [Agda](https://github.com/tree-sitter/tree-sitter-agda) |  | _not available_ |
+| [Agda](https://github.com/cengelbart39/tree-sitter-agda/tree/feat/spm) | ✅ | _not available_ |
 | [Bash](https://github.com/lukepistrol/tree-sitter-bash) | ✅ | ✅ |
 | [C](https://github.com/tree-sitter/tree-sitter-c) | ✅ | ✅ |
 | [C++](https://github.com/tree-sitter/tree-sitter-cpp) | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ In order to add support for additional languages we have a complete guide on how
 | [JSDoc](https://github.com/cengelbart39/tree-sitter-jsdoc/tree/feature/spm) | ✅ | ✅ |
 | [JSON](https://github.com/tree-sitter/tree-sitter-json) | ✅ | ✅ |
 | [Julia](https://github.com/tree-sitter/tree-sitter-julia) | ✅ | _not available_ |
-| [JSON](https://github.com/tree-sitter/tree-sitter-json) | ✅ | ✅ |
 | [Kotlin](https://github.com/lukepistrol/tree-sitter-kotlin/tree/feature/spm-queries) | ✅ | ✅ |
 | [Lua](https://github.com/lukepistrol/tree-sitter-lua/tree/feature/spm) | ✅ | ✅ |
 | [Markdown](https://github.com/MDeiml/tree-sitter-markdown) | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In order to add support for additional languages we have a complete guide on how
 | [JavaScript/JSX](https://github.com/tree-sitter/tree-sitter-javascript) | ✅ | ✅ |
 | [JSDoc](https://github.com/cengelbart39/tree-sitter-jsdoc/tree/feature/spm) | ✅ | ✅ |
 | [JSON](https://github.com/mattmassicotte/tree-sitter-json) | ✅ | ✅ |
-| [Julia](https://github.com/tree-sitter/tree-sitter-julia) |  | _not available_ |
+| [Julia](https://github.com/tree-sitter/tree-sitter-julia) | ✅ | _not available_ |
 | [Kotlin](https://github.com/lukepistrol/tree-sitter-kotlin/tree/feature/spm-queries) | ✅ | ✅ |
 | [Lua](https://github.com/lukepistrol/tree-sitter-lua/tree/feature/spm) | ✅ | ✅ |
 | [Markdown](https://github.com/MDeiml/tree-sitter-markdown) | ✅ | ✅ |

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -11,6 +11,7 @@ public extension CodeLanguage {
 
     /// An array of all language structures.
     static let allLanguages: [CodeLanguage] = [
+        .agda,
         .bash,
         .c,
         .cpp,
@@ -49,6 +50,13 @@ public extension CodeLanguage {
         .yaml,
         .zig
     ]
+
+    /// A language structure for `Agda`
+    static let agda: CodeLanguage = .init(
+        id: .agda,
+        tsName: "agda",
+        extensions: ["agda"]
+    )
 
     /// A language structure for `Bash`
     static let bash: CodeLanguage = .init(

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -29,6 +29,7 @@ public extension CodeLanguage {
         .jsdoc,
         .json,
         .jsx,
+        .julia,
         .kotlin,
         .lua,
         .markdown,
@@ -182,6 +183,13 @@ public extension CodeLanguage {
         tsName: "javascript",
         extensions: ["jsx"],
         highlights: ["highlights-jsx", "injections"]
+    )
+
+    /// A language structure for `Julia`
+    static let julia: CodeLanguage = .init(
+        id: .julia,
+        tsName: "julia",
+        extensions: ["jl"]
     )
 
     /// A language structure for `Kotlin`

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -49,6 +49,7 @@ public extension CodeLanguage {
         .toml,
         .tsx,
         .typescript,
+        .verilog,
         .yaml,
         .zig
     ]
@@ -332,6 +333,13 @@ public extension CodeLanguage {
         tsName: "typescript",
         extensions: ["ts"],
         parentURL: CodeLanguage.javascript.queryURL
+    )
+
+    /// A language structure for `Verilog`
+    static let verilog: CodeLanguage = .init(
+        id: .verilog,
+        tsName: "verilog",
+        extensions: ["v"]
     )
 
     /// A language structure for `YAML`

--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -37,6 +37,7 @@ public extension CodeLanguage {
         .objc,
         .ocaml,
         .ocamlInterface,
+        .perl,
         .php,
         .python,
         .regex,
@@ -242,6 +243,13 @@ public extension CodeLanguage {
         id: .ocamlInterface,
         tsName: "ocaml",
         extensions: ["mli"]
+    )
+
+    /// A language structure for `Perl`
+    static let perl: CodeLanguage = .init(
+        id: .perl,
+        tsName: "perl",
+        extensions: ["pl", "pm"]
     )
 
     /// A language structure for `PHP`

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -108,6 +108,8 @@ public struct CodeLanguage {
             return tree_sitter_json()
         case .jsx:
             return tree_sitter_javascript()
+        case .julia:
+            return tree_sitter_julia()
         case .kotlin:
             return tree_sitter_kotlin()
         case .lua:

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -72,6 +72,8 @@ public struct CodeLanguage {
     /// Gets the TSLanguage from `tree-sitter`
     private var tsLanguage: UnsafeMutablePointer<TSLanguage>? {
         switch id {
+        case .agda:
+            return tree_sitter_agda()
         case .bash:
             return tree_sitter_bash()
         case .c:

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -124,6 +124,8 @@ public struct CodeLanguage {
             return tree_sitter_ocaml()
         case .ocamlInterface:
             return tree_sitter_ocaml_interface()
+        case .perl:
+            return tree_sitter_perl()
         case .php:
             return tree_sitter_php()
         case .python:

--- a/Sources/CodeEditLanguages/CodeLanguage.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage.swift
@@ -148,6 +148,8 @@ public struct CodeLanguage {
             return tree_sitter_tsx()
         case .typescript:
             return tree_sitter_typescript()
+        case .verilog:
+            return tree_sitter_verilog()
         case .yaml:
             return tree_sitter_yaml()
         case .zig:

--- a/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
@@ -51,6 +51,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - SQL
 - Swift
 - TOML
+- Verilog
 - YAML
 - Zig
 
@@ -108,6 +109,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - ``sql``
 - ``swift``
 - ``toml``
+- ``verilog``
 - ``yaml``
 - ``zig``
 

--- a/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
@@ -42,6 +42,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - Markdown
 - Objective C
 - OCaml / OCaml Interface
+- Perl
 - PHP
 - Python
 - Ruby
@@ -98,6 +99,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - ``markdown``
 - ``markdownInline``
 - ``objc``
+- ``perl``
 - ``php``
 - ``python``
 - ``ruby``

--- a/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
@@ -36,6 +36,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - JavaScript
 - JSON
 - JSX
+- Julia
 - Kotlin
 - Lua
 - Markdown
@@ -73,6 +74,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 
 - ``allLanguages``
 - ``default``
+- ``agda``
 - ``bash``
 - ``c``
 - ``cpp``
@@ -90,6 +92,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - ``jsdoc``
 - ``json``
 - ``jsx``
+- ``julia``
 - ``kotlin``
 - ``lua``
 - ``markdown``

--- a/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/CodeLanguage.md
@@ -19,6 +19,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 
 ### Supported Languages
 
+- Agda
 - Bash
 - C
 - C++

--- a/Sources/CodeEditLanguages/Documentation.docc/TreeSitterModel.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/TreeSitterModel.md
@@ -32,6 +32,7 @@ let query = TreeSitterModel.shared.swiftQuery
 
 ### Instance Properties
 
+- ``agdaQuery``
 - ``bashQuery``
 - ``cQuery``
 - ``cppQuery``

--- a/Sources/CodeEditLanguages/Documentation.docc/TreeSitterModel.md
+++ b/Sources/CodeEditLanguages/Documentation.docc/TreeSitterModel.md
@@ -32,7 +32,6 @@ let query = TreeSitterModel.shared.swiftQuery
 
 ### Instance Properties
 
-- ``agdaQuery``
 - ``bashQuery``
 - ``cQuery``
 - ``cppQuery``

--- a/Sources/CodeEditLanguages/TreeSitterLanguage.swift
+++ b/Sources/CodeEditLanguages/TreeSitterLanguage.swift
@@ -27,6 +27,7 @@ public enum TreeSitterLanguage: String {
     case jsdoc
     case json
     case jsx
+    case julia
     case kotlin
     case lua
     case markdown

--- a/Sources/CodeEditLanguages/TreeSitterLanguage.swift
+++ b/Sources/CodeEditLanguages/TreeSitterLanguage.swift
@@ -47,6 +47,7 @@ public enum TreeSitterLanguage: String {
     case toml
     case tsx
     case typescript
+    case verilog
     case yaml
     case zig
     case plainText

--- a/Sources/CodeEditLanguages/TreeSitterLanguage.swift
+++ b/Sources/CodeEditLanguages/TreeSitterLanguage.swift
@@ -9,6 +9,7 @@ import Foundation
 
 /// A collection of languages that are supported by `tree-sitter`
 public enum TreeSitterLanguage: String {
+    case agda
     case bash
     case c
     case cpp

--- a/Sources/CodeEditLanguages/TreeSitterLanguage.swift
+++ b/Sources/CodeEditLanguages/TreeSitterLanguage.swift
@@ -35,6 +35,7 @@ public enum TreeSitterLanguage: String {
     case objc
     case ocaml
     case ocamlInterface
+    case perl
     case php
     case python
     case regex

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -20,6 +20,8 @@ public class TreeSitterModel {
     public func query(for language: TreeSitterLanguage) -> Query? {
         // swiftlint:disable:previous cyclomatic_complexity function_body_length
         switch language {
+        case .agda:
+            return agdaQuery
         case .bash:
             return bashQuery
         case .c:
@@ -98,6 +100,11 @@ public class TreeSitterModel {
             return nil
         }
     }
+
+    /// Query for `Agda` files.
+    public private(set) lazy var agdaQuery: Query? = {
+        return queryFor(.agda)
+    }()
 
     /// Query for `Bash` files.
     public private(set) lazy var bashQuery: Query? = {

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -96,6 +96,8 @@ public class TreeSitterModel {
             return tsxQuery
         case .typescript:
             return typescriptQuery
+        case .verilog:
+            return nil
         case .yaml:
             return yamlQuery
         case .zig:

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -72,6 +72,8 @@ public class TreeSitterModel {
             return ocamlQuery
         case .ocamlInterface:
             return ocamlInterfaceQuery
+        case .perl:
+            return nil
         case .php:
             return phpQuery
         case .python:

--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -21,7 +21,7 @@ public class TreeSitterModel {
         // swiftlint:disable:previous cyclomatic_complexity function_body_length
         switch language {
         case .agda:
-            return agdaQuery
+            return nil
         case .bash:
             return bashQuery
         case .c:
@@ -56,6 +56,8 @@ public class TreeSitterModel {
             return jsonQuery
         case .jsx:
             return jsxQuery
+        case .julia:
+            return nil
         case .kotlin:
             return kotlinQuery
         case .lua:
@@ -100,11 +102,6 @@ public class TreeSitterModel {
             return nil
         }
     }
-
-    /// Query for `Agda` files.
-    public private(set) lazy var agdaQuery: Query? = {
-        return queryFor(.agda)
-    }()
 
     /// Query for `Bash` files.
     public private(set) lazy var bashQuery: Query? = {

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -552,7 +552,22 @@ final class CodeEditLanguagesTests: XCTestCase {
         XCTAssertNotNil(query)
         XCTAssertNotEqual(query?.patternCount, 0)
     }
-    
+
+// MARK: - Perl
+    func test_CodeLanguagePerl() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.pl")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .perl)
+    }
+
+    func test_CodeLanguagePerl2() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.pm")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .perl)
+    }
+
 // MARK: - PHP
 
     func test_CodeLanguagePHP() throws {

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -766,6 +766,15 @@ final class CodeEditLanguagesTests: XCTestCase {
         XCTAssertNotEqual(query?.patternCount, 0)
     }
 
+// MARK: - Verilog
+
+    func test_CodeLanguageVerilog() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.v")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .verilog)
+    }
+
 // MARK: - YAML
 
     func test_CodeLanguageYAML() throws {

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -13,6 +13,24 @@ final class CodeEditLanguagesTests: XCTestCase {
 
     let bundleURL = Bundle.module.resourceURL
 
+// MARK: - Agda
+    func test_CodeLanguageAgda() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.agda")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .agda)
+    }
+
+    func test_FetchQueryAgda() throws {
+        var language = CodeLanguage.bash
+        language.resourceURL = bundleURL
+        
+        let data = try Data(contentsOf: language.queryURL!)
+        let query = try? Query(language: language.language!, data: data)
+        XCTAssertNotNil(query)
+        XCTAssertNotEqual(query?.patternCount, 0)
+    }
+    
 // MARK: - Bash
 
     func test_CodeLanguageBash() throws {

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -14,21 +14,12 @@ final class CodeEditLanguagesTests: XCTestCase {
     let bundleURL = Bundle.module.resourceURL
 
 // MARK: - Agda
+    
     func test_CodeLanguageAgda() throws {
         let url = URL(fileURLWithPath: "~/path/to/file.agda")
         let language = CodeLanguage.detectLanguageFrom(url: url)
 
         XCTAssertEqual(language.id, .agda)
-    }
-
-    func test_FetchQueryAgda() throws {
-        var language = CodeLanguage.bash
-        language.resourceURL = bundleURL
-        
-        let data = try Data(contentsOf: language.queryURL!)
-        let query = try? Query(language: language.language!, data: data)
-        XCTAssertNotNil(query)
-        XCTAssertNotEqual(query?.patternCount, 0)
     }
     
 // MARK: - Bash
@@ -387,6 +378,15 @@ final class CodeEditLanguagesTests: XCTestCase {
         let query = try? Query(language: language.language!, data: data)
         XCTAssertNotNil(query)
         XCTAssertNotEqual(query?.patternCount, 0)
+    }
+
+// MARK: - Julia
+
+    func test_CodeLanguageJulia() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.jl")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .julia)
     }
 
 // MARK: - Kotlin


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds support for the 4 no-highlight grammars in the `README`, being:
- `Agda`
- `Julia`
- `Perl`
- `Verilog`

All but `Agda` use their official repo.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #10

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

<!--- ### Screenshots -->

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
