### PR TITLE
Fix EXE_BAD_ACCESS error on Dart

### DIFF
--- a/Sources/CodeEditLanguages/TreeSitterModel.swift
+++ b/Sources/CodeEditLanguages/TreeSitterModel.swift
@@ -126,7 +126,7 @@ public class TreeSitterModel {
 
     /// Query for `Dart` files.
     public private(set) lazy var dartQuery: Query? = {
-        return query(for: .dart)
+        return queryFor(.dart)
     }()
 
     /// Query for `Dockerfile` files.


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Fixes a bad access error on Dart due to a typo calling the wrong method.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
