### PR TITLE
add:  `c++` extension to `cpp` known extensions 🔨

### DIFF
--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -68,7 +68,7 @@ public extension CodeLanguage {
     static let cpp: CodeLanguage = .init(
         id: .cpp,
         tsName: "cpp",
-        extensions: ["cc", "cpp", "hpp", "h"],
+        extensions: ["cc", "cpp", "c++", "hpp", "h"],
         parentURL: CodeLanguage.c.queryURL,
         highlights: ["injections"]
     )


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
I've added `c++` extension to known extensions of cpp, to allow recognition of files of this extension as c plus plus ones

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues
N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots
N/A
