### PR TITLE
Add `shtml` extension to known `HTML` extensions

### DIFF
--- a/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
+++ b/Sources/CodeEditLanguages/CodeLanguage+Definitions.swift
@@ -145,7 +145,7 @@ public extension CodeLanguage {
     static let html: CodeLanguage = .init(
         id: .html,
         tsName: "html",
-        extensions: ["html", "htm"],
+        extensions: ["html", "htm", "shtml"],
         highlights: ["injections"]
     )
 

--- a/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
+++ b/Tests/CodeEditLanguagesTests/CodeEditLanguagesTests.swift
@@ -274,6 +274,13 @@ final class CodeEditLanguagesTests: XCTestCase {
 
         XCTAssertEqual(language.id, .html)
     }
+    
+    func test_CodeLanguageHTML3() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.shtml")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .html)
+    }
 
     func test_FetchQueryHTML() throws {
         var language = CodeLanguage.html


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds `shtml` as a file extension under HTML.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* Closes #53 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

<!--- ### Screenshots -->

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
