### PR TITLE
Fix framework symlink resolution error by add -y to zip command in build_framework.sh

### DIFF
--- a/build_framework.sh
+++ b/build_framework.sh
@@ -59,7 +59,7 @@ xcodebuild \
 
 # zip the xcframework
 status "Zipping CodeLanguagesContainer.xcframework..."
-zip -r -q "$OUTPUT_PATH".zip "$OUTPUT_PATH"
+zip -r -q -y "$OUTPUT_PATH".zip "$OUTPUT_PATH"
 
 # remove the unzipped xcframework
 rm -rf "$OUTPUT_PATH"


### PR DESCRIPTION
Fix framework symlink resolution error by add -y to zip command in build_framework.sh
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

The `CodeLanguagesContainer.xcframework.zip` is currently generated using the following command:

```bash
zip -r -q "$OUTPUT_PATH".zip "$OUTPUT_PATH"
```

This method stores multiple copies of symlinked files, which may trigger warnings in recent versions of Xcode (I have observed this from Xcode 15.3), as well as in Xcode Cloud. It also fails AppStore Connect and TestFlight validations.

The solution is to simply add the `-y` option to the zip command, which also reduces the size of the `CodeLanguagesContainer.xcframework.zip` to about one-third of the original size. However, I have not updated the zip file in this pull request to avoid breaking anything.

Reference:
https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html

Related errors:

```
// Xcode Warning
Couldn't resolve framework symlink for '/Users/fdgogogo/Library/Developer/Xcode/DerivedData/testCodeEditLanguages-groqwydmdwrvfyaszdujzagultat/SourcePackages/artifacts/codeeditlanguages/CodeLanguagesContainer/CodeLanguagesContainer.xcframework/macos-arm64/CodeLanguages_Container.framework/Versions/Current': readlink(/Users/fdgogogo/Library/Developer/Xcode/DerivedData/testCodeEditLanguages-groqwydmdwrvfyaszdujzagultat/SourcePackages/artifacts/codeeditlanguages/CodeLanguagesContainer/CodeLanguagesContainer.xcframework/macos-arm64/CodeLanguages_Container.framework/Versions/Current): Invalid argument (22)

// Validation failed message
ITMS-90260: Bad Bundle Executable - You must include a valid CFBundleExecutable key in the nested bundle CodeLanguages_Container [tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework] property list file.

ITMS-90261: Bad CFBundleExecutable - Cannot find executable file that matches the value of CFBundleExecutable in the nested bundle CodeLanguages_Container [tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework] property list file.

ITMS-90260: Bad Bundle Executable - You must include a valid CFBundleExecutable key in the nested bundle CodeLanguages_Container [tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework/Versions/Current] property list file.

ITMS-90261: Bad CFBundleExecutable - Cannot find executable file that matches the value of CFBundleExecutable in the nested bundle CodeLanguages_Container [tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework/Versions/Current] property list file.

ITMS-90238: Invalid Signature - The main app bundle RedisDesk at path RedisDesk.app has following signing error(s): --prepared:/Volumes/workspace/app_data/SWValidationService/mz_11704184603604999049dir/mz_13611323355036277151dir/tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework/Versions/Current/. --prepared:/Volumes/workspace/app_data/SWValidationService/mz_11704184603604999049dir/mz_13611323355036277151dir/tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/HexFiend.framework/Versions/Current/. --validated:/Volumes/workspace/app_data/SWValidationService/mz_11704184603604999049dir/mz_13611323355036277151dir/tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/HexFiend.framework/Versions/Current/. /Volumes/workspace/app_data/SWValidationService/mz_11704184603604999049dir/mz_13611323355036277151dir/tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app: bundle format is ambiguous (could be app or framework) In subcomponent: /Volumes/workspace/app_data/SWValidationService/mz_11704184603604999049dir/mz_13611323355036277151dir/tech.jiaanf.RedisDesk.pkg/Payload/RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework . Refer to the Code Signing and Application Sandboxing Guide at http://developer.apple.com/library/mac/#documentation/Security/Conceptual/CodeSigningGuide/AboutCS/AboutCS.html and Technical Note 2206 at https://developer.apple.com/library/mac/technotes/tn2206/_index.html for more information.

ITMS-90291: Malformed Framework - The framework bundle CodeLanguages_Container (RedisDesk.app/Contents/Frameworks/CodeLanguages_Container.framework) must contain a symbolic link 'Resources' -> 'Versions/Current/Resources'. Refer to the [Anatomy of Framework Bundles](http://developer.apple.com/library/mac/#documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html) for more information.
```



### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #ISSUE_NUMBER

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
