### PR TITLE
Update Build Script, Include `arm` and `x86`

### DIFF
--- a/build_framework.sh
+++ b/build_framework.sh
@@ -37,6 +37,8 @@ xcodebuild \
     -destination "platform=macOS" \
     -derivedDataPath DerivedData \
     -configuration Release \
+    ARCHS="arm64 x86_64" \
+    ONLY_ACTIVE_ARCH=NO \
     $QUIET_FLAG clean build &> $QUIET_OUTPUT
 status "Build complete!"
 


### PR DESCRIPTION
### Description

Updates build script to build a fat binary for both x86 and arm. New zip file is 33MB, which is still 1/3 the size it was before 56edd6e200ebd43d940d93045960698439396c6f.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
