### PR TITLE
Pull Missing Query Files

### DIFF
--- a/Sources/CodeEditLanguages/Resources/tree-sitter-agda/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-agda/folds.scm
@@ -1,0 +1,19 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (record)
+  (module)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-agda/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-agda/injections.scm
@@ -1,0 +1,17 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-bash/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-bash/folds.scm
@@ -1,0 +1,24 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (function_definition)
+  (if_statement)
+  (case_statement)
+  (for_statement)
+  (while_statement)
+  (c_style_for_statement)
+  (heredoc_redirect)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-bash/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-bash/injections.scm
@@ -1,0 +1,94 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((regex) @injection.content
+  (#set! injection.language "regex"))
+
+((heredoc_redirect
+  (heredoc_body) @injection.content
+  (heredoc_end) @injection.language)
+  (#downcase! @injection.language))
+
+; printf 'format'
+((command
+  name: (command_name) @_command
+  .
+  argument: [
+    (string) @injection.content
+    (concatenation
+      (string) @injection.content)
+    (raw_string) @injection.content
+    (concatenation
+      (raw_string) @injection.content)
+  ])
+  (#eq? @_command "printf")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  (#set! injection.language "printf"))
+
+; printf -v var 'format'
+((command
+  name: (command_name) @_command
+  argument: (word) @_arg
+  .
+  (_)
+  .
+  argument: [
+    (string) @injection.content
+    (concatenation
+      (string) @injection.content)
+    (raw_string) @injection.content
+    (concatenation
+      (raw_string) @injection.content)
+  ])
+  (#eq? @_command "printf")
+  (#eq? @_arg "-v")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  (#set! injection.language "printf"))
+
+; printf -- 'format'
+((command
+  name: (command_name) @_command
+  argument: (word) @_arg
+  .
+  argument: [
+    (string) @injection.content
+    (concatenation
+      (string) @injection.content)
+    (raw_string) @injection.content
+    (concatenation
+      (raw_string) @injection.content)
+  ])
+  (#eq? @_command "printf")
+  (#eq? @_arg "--")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  (#set! injection.language "printf"))
+
+((command
+  name: (command_name) @_command
+  .
+  argument: [
+    (string)
+    (raw_string)
+  ] @injection.content)
+  (#eq? @_command "bind")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  (#set! injection.language "readline"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-bash/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-bash/locals.scm
@@ -1,0 +1,29 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Scopes
+(function_definition) @local.scope
+
+; Definitions
+(variable_assignment
+  name: (variable_name) @local.definition.var)
+
+(function_definition
+  name: (word) @local.definition.function)
+
+; References
+(variable_name) @local.reference
+
+(word) @local.reference

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c-sharp/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c-sharp/folds.scm
@@ -1,0 +1,32 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+body: [
+  (declaration_list)
+  (switch_body)
+  (enum_member_declaration_list)
+] @fold
+
+accessors: (accessor_list) @fold
+
+initializer: (initializer_expression) @fold
+
+[
+  (block)
+  (preproc_if)
+  (preproc_elif)
+  (preproc_else)
+  (using_directive)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c-sharp/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c-sharp/injections.scm
@@ -1,0 +1,17 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c-sharp/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c-sharp/locals.scm
@@ -1,0 +1,57 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Definitions
+(variable_declarator
+  .
+  (identifier) @local.definition.var)
+
+(variable_declarator
+  (tuple_pattern
+    (identifier) @local.definition.var))
+
+(declaration_expression
+  name: (identifier) @local.definition.var)
+
+(foreach_statement
+  left: (identifier) @local.definition.var)
+
+(foreach_statement
+  left: (tuple_pattern
+    (identifier) @local.definition.var))
+
+(parameter
+  (identifier) @local.definition.parameter)
+
+(method_declaration
+  name: (identifier) @local.definition.method)
+
+(local_function_statement
+  name: (identifier) @local.definition.method)
+
+(property_declaration
+  name: (identifier) @local.definition)
+
+(type_parameter
+  (identifier) @local.definition.type)
+
+(class_declaration
+  name: (identifier) @local.definition)
+
+; References
+(identifier) @local.reference
+
+; Scope
+(block) @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c/folds.scm
@@ -1,0 +1,38 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (for_statement)
+  (if_statement)
+  (while_statement)
+  (do_statement)
+  (switch_statement)
+  (case_statement)
+  (function_definition)
+  (struct_specifier)
+  (enum_specifier)
+  (comment)
+  (preproc_if)
+  (preproc_elif)
+  (preproc_else)
+  (preproc_ifdef)
+  (preproc_function_def)
+  (initializer_list)
+  (gnu_asm_expression)
+  (preproc_include)+
+] @fold
+
+(compound_statement
+  (compound_statement) @fold)

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c/indents.scm
@@ -1,0 +1,114 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (compound_statement)
+  (field_declaration_list)
+  (case_statement)
+  (enumerator_list)
+  (compound_literal_expression)
+  (initializer_list)
+  (init_declarator)
+] @indent.begin
+
+; With current indent logic, if we capture expression_statement with @indent.begin
+; It will be affected by _parent_ node with error subnodes deep down the tree
+; So narrow indent capture to check for error inside expression statement only,
+(expression_statement
+  (_) @indent.begin
+  ";" @indent.end)
+
+(ERROR
+  "for"
+  "(" @indent.begin
+  ";"
+  ";"
+  ")" @indent.end)
+
+((for_statement
+  body: (_) @_body) @indent.begin
+  (#not-kind-eq? @_body "compound_statement"))
+
+(while_statement
+  condition: (_) @indent.begin)
+
+((while_statement
+  body: (_) @_body) @indent.begin
+  (#not-kind-eq? @_body "compound_statement"))
+
+((if_statement)
+  .
+  (ERROR
+    "else" @indent.begin))
+
+(if_statement
+  condition: (_) @indent.begin)
+
+; Supports if without braces (but not both if-else without braces)
+(if_statement
+  consequence: (_
+    ";" @indent.end) @_consequence
+  (#not-kind-eq? @_consequence "compound_statement")
+  alternative: (else_clause
+    "else" @indent.branch
+    [
+      (if_statement
+        (compound_statement) @indent.dedent)? @indent.dedent
+      (compound_statement)? @indent.dedent
+      (_)? @indent.dedent
+    ])?) @indent.begin
+
+(else_clause
+  (_
+    .
+    "{" @indent.branch))
+
+(compound_statement
+  "}" @indent.end)
+
+[
+  ")"
+  "}"
+  (statement_identifier)
+] @indent.branch
+
+[
+  "#define"
+  "#ifdef"
+  "#ifndef"
+  "#elif"
+  "#if"
+  "#else"
+  "#endif"
+] @indent.zero
+
+[
+  (preproc_arg)
+  (string_literal)
+] @indent.ignore
+
+((ERROR
+  (parameter_declaration)) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+([
+  (argument_list)
+  (parameter_list)
+] @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+(comment) @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c/injections.scm
@@ -1,0 +1,143 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((preproc_arg) @injection.content
+  (#set! injection.language "c"))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((comment) @injection.content
+  (#match? @injection.content "/\\*!([a-zA-Z]+:)?re2c")
+  (#set! injection.language "re2c"))
+
+((comment) @injection.content
+  (#lua-match? @injection.content "/[*\/][!*\/]<?[^a-zA-Z]")
+  (#set! injection.language "doxygen"))
+
+((call_expression
+  function: (identifier) @_function
+  arguments: (argument_list
+    .
+    [
+      (string_literal
+        (string_content) @injection.content)
+      (concatenated_string
+        (string_literal
+          (string_content) @injection.content))
+    ]))
+  ; format-ignore
+  (#any-of? @_function 
+    "printf" "printf_s"
+    "vprintf" "vprintf_s"
+    "scanf" "scanf_s"
+    "vscanf" "vscanf_s"
+    "wprintf" "wprintf_s"
+    "vwprintf" "vwprintf_s"
+    "wscanf" "wscanf_s"
+    "vwscanf" "vwscanf_s"
+    "cscanf" "_cscanf"
+    "printw"
+    "scanw")
+  (#set! injection.language "printf"))
+
+((call_expression
+  function: (identifier) @_function
+  arguments: (argument_list
+    (_)
+    .
+    [
+      (string_literal
+        (string_content) @injection.content)
+      (concatenated_string
+        (string_literal
+          (string_content) @injection.content))
+    ]))
+  ; format-ignore
+  (#any-of? @_function 
+    "fprintf" "fprintf_s"
+    "sprintf"
+    "dprintf"
+    "fscanf" "fscanf_s"
+    "sscanf" "sscanf_s"
+    "vsscanf" "vsscanf_s"
+    "vfprintf" "vfprintf_s"
+    "vsprintf"
+    "vdprintf"
+    "fwprintf" "fwprintf_s"
+    "vfwprintf" "vfwprintf_s"
+    "fwscanf" "fwscanf_s"
+    "swscanf" "swscanf_s"
+    "vswscanf" "vswscanf_s"
+    "vfscanf" "vfscanf_s"
+    "vfwscanf" "vfwscanf_s"
+    "wprintw"
+    "vw_printw" "vwprintw"
+    "wscanw"
+    "vw_scanw" "vwscanw")
+  (#set! injection.language "printf"))
+
+((call_expression
+  function: (identifier) @_function
+  arguments: (argument_list
+    (_)
+    .
+    (_)
+    .
+    [
+      (string_literal
+        (string_content) @injection.content)
+      (concatenated_string
+        (string_literal
+          (string_content) @injection.content))
+    ]))
+  ; format-ignore
+  (#any-of? @_function 
+    "sprintf_s"
+    "snprintf" "snprintf_s"
+    "vsprintf_s"
+    "vsnprintf" "vsnprintf_s"
+    "swprintf" "swprintf_s"
+    "snwprintf_s"
+    "vswprintf" "vswprintf_s"
+    "vsnwprintf_s"
+    "mvprintw"
+    "mvscanw")
+  (#set! injection.language "printf"))
+
+((call_expression
+  function: (identifier) @_function
+  arguments: (argument_list
+    (_)
+    .
+    (_)
+    .
+    (_)
+    .
+    [
+      (string_literal
+        (string_content) @injection.content)
+      (concatenated_string
+        (string_literal
+          (string_content) @injection.content))
+    ]))
+  (#any-of? @_function "mvwprintw" "mvwscanw")
+  (#set! injection.language "printf"))
+
+; TODO: add when asm is added
+; (gnu_asm_expression assembly_code: (string_literal) @injection.content
+; (#set! injection.language "asm"))
+; (gnu_asm_expression assembly_code: (concatenated_string (string_literal) @injection.content)
+; (#set! injection.language "asm"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-c/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-c/locals.scm
@@ -1,0 +1,82 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Functions definitions
+(function_declarator
+  declarator: (identifier) @local.definition.function)
+
+(preproc_function_def
+  name: (identifier) @local.definition.macro) @local.scope
+
+(preproc_def
+  name: (identifier) @local.definition.macro)
+
+(pointer_declarator
+  declarator: (identifier) @local.definition.var)
+
+(parameter_declaration
+  declarator: (identifier) @local.definition.parameter)
+
+(init_declarator
+  declarator: (identifier) @local.definition.var)
+
+(array_declarator
+  declarator: (identifier) @local.definition.var)
+
+(declaration
+  declarator: (identifier) @local.definition.var)
+
+(enum_specifier
+  name: (_) @local.definition.type
+  (enumerator_list
+    (enumerator
+      name: (identifier) @local.definition.var)))
+
+; Type / Struct / Enum
+(field_declaration
+  declarator: (field_identifier) @local.definition.field)
+
+(type_definition
+  declarator: (type_identifier) @local.definition.type)
+
+(struct_specifier
+  name: (type_identifier) @local.definition.type)
+
+; goto
+(labeled_statement
+  (statement_identifier) @local.definition)
+
+; References
+(identifier) @local.reference
+
+((field_identifier) @local.reference
+  (#set! reference.kind "field"))
+
+((type_identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(goto_statement
+  (statement_identifier) @local.reference)
+
+; Scope
+[
+  (for_statement)
+  (if_statement)
+  (while_statement)
+  (translation_unit)
+  (function_definition)
+  (compound_statement) ; a block in curly braces
+  (struct_specifier)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-cpp/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-cpp/folds.scm
@@ -1,0 +1,29 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: c
+
+[
+  (for_range_loop)
+  (class_specifier)
+  (field_declaration
+    type: (enum_specifier)
+    default_value: (initializer_list))
+  (template_declaration)
+  (namespace_definition)
+  (try_statement)
+  (catch_clause)
+  (lambda_expression)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-cpp/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-cpp/indents.scm
@@ -1,0 +1,23 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: c
+
+(condition_clause) @indent.begin
+
+((field_initializer_list) @indent.begin
+  (#set! indent.start_at_same_line 1))
+
+(access_specifier) @indent.branch

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-cpp/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-cpp/locals.scm
@@ -1,0 +1,93 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: c
+
+; Parameters
+(variadic_parameter_declaration
+  declarator: (variadic_declarator
+    (identifier) @local.definition.parameter))
+
+(optional_parameter_declaration
+  declarator: (identifier) @local.definition.parameter)
+
+; Class / struct definitions
+(class_specifier) @local.scope
+
+(reference_declarator
+  (identifier) @local.definition.var)
+
+(variadic_declarator
+  (identifier) @local.definition.var)
+
+(struct_specifier
+  name: (qualified_identifier
+    name: (type_identifier) @local.definition.type))
+
+(class_specifier
+  name: (type_identifier) @local.definition.type)
+
+(concept_definition
+  name: (identifier) @local.definition.type)
+
+(class_specifier
+  name: (qualified_identifier
+    name: (type_identifier) @local.definition.type))
+
+(alias_declaration
+  name: (type_identifier) @local.definition.type)
+
+;template <typename T>
+(type_parameter_declaration
+  (type_identifier) @local.definition.type)
+
+(template_declaration) @local.scope
+
+; Namespaces
+(namespace_definition
+  name: (namespace_identifier) @local.definition.namespace
+  body: (_) @local.scope)
+
+(namespace_definition
+  name: (nested_namespace_specifier) @local.definition.namespace
+  body: (_) @local.scope)
+
+((namespace_identifier) @local.reference
+  (#set! reference.kind "namespace"))
+
+; Function definitions
+(template_function
+  name: (identifier) @local.definition.function) @local.scope
+
+(template_method
+  name: (field_identifier) @local.definition.method) @local.scope
+
+(function_declarator
+  declarator: (qualified_identifier
+    name: (identifier) @local.definition.function)) @local.scope
+
+(field_declaration
+  declarator: (function_declarator
+    (field_identifier) @local.definition.method))
+
+(lambda_expression) @local.scope
+
+; Control structures
+(try_statement
+  body: (_) @local.scope)
+
+(catch_clause) @local.scope
+
+(requires_expression) @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-css/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-css/folds.scm
@@ -1,0 +1,25 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  ; top-level block statements from https://github.com/tree-sitter/tree-sitter-css/blob/master/grammar.js
+  ; note: (block) is not used due to unideal behavior when node before block node spans multiple lines
+  (rule_set)
+  (at_rule)
+  (supports_statement)
+  (media_statement)
+  (keyframe_block)
+  (import_statement)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-css/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-css/indents.scm
@@ -1,0 +1,26 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (block)
+  (declaration)
+] @indent.begin
+
+(block
+  "}" @indent.branch)
+
+"}" @indent.dedent
+
+(comment) @indent.ignore

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-css/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-css/injections.scm
@@ -1,0 +1,17 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-dart/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-dart/folds.scm
@@ -1,0 +1,28 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (class_definition)
+  (enum_declaration)
+  (extension_declaration)
+  (arguments)
+  (function_body)
+  (block)
+  (switch_block)
+  (list_literal)
+  (set_or_map_literal)
+  (string_literal)
+  (import_or_export)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-dart/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-dart/indents.scm
@@ -1,0 +1,64 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (class_body)
+  (function_body)
+  (function_expression_body)
+  (declaration
+    (initializers))
+  (switch_block)
+  (formal_parameter_list)
+  (formal_parameter)
+  (list_literal)
+  (return_statement)
+  (arguments)
+  (try_statement)
+] @indent.begin
+
+(switch_block
+  (_) @indent.begin
+  (#set! indent.immediate 1)
+  (#set! indent.start_at_same_line 1))
+
+[
+  (switch_statement_case)
+  (switch_statement_default)
+] @indent.branch
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @indent.branch
+
+"}" @indent.end
+
+(return_statement
+  ";" @indent.end)
+
+(break_statement
+  ";" @indent.end)
+
+(comment) @indent.ignore
+
+; dedenting the else block is painfully slow; replace with simpler strategy
+; (if_statement) @indent.begin
+; (if_statement
+;   (block) @indent.branch)
+(if_statement) @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-dart/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-dart/injections.scm
@@ -1,0 +1,17 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-dart/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-dart/locals.scm
@@ -1,0 +1,47 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Definitions
+(function_signature
+  name: (identifier) @local.definition.function)
+
+(formal_parameter
+  name: (identifier) @local.definition.parameter)
+
+(initialized_variable_definition
+  name: (identifier) @local.definition.var)
+
+(initialized_identifier
+  (identifier) @local.definition.var)
+
+(static_final_declaration
+  (identifier) @local.definition.var)
+
+; References
+(identifier) @local.reference
+
+; Scopes
+(class_definition
+  body: (_) @local.scope)
+
+[
+  (block)
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (try_statement)
+  (catch_clause)
+  (finally_clause)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-dockerfile/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-dockerfile/injections.scm
@@ -1,0 +1,27 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((shell_command
+  (shell_fragment) @injection.content)
+  (#set! injection.language "bash")
+  (#set! injection.combined))
+
+((run_instruction
+  (heredoc_block) @injection.content)
+  (#set! injection.language "bash")
+  (#set! injection.include-children))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-elixir/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-elixir/folds.scm
@@ -1,0 +1,25 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (anonymous_function)
+  (stab_clause)
+  (arguments)
+  (block)
+  (do_block)
+  (list)
+  (map)
+  (tuple)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-elixir/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-elixir/indents.scm
@@ -1,0 +1,40 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (block)
+  (do_block)
+  (list)
+  (map)
+  (stab_clause)
+  (tuple)
+  (arguments)
+] @indent.begin
+
+[
+  ")"
+  "]"
+  "after"
+  "catch"
+  "else"
+  "rescue"
+  "}"
+  "end"
+] @indent.end @indent.branch
+
+; Elixir pipelines are not indented, but other binary operator chains are
+((binary_operator
+  operator: _ @_operator) @indent.begin
+  (#not-eq? @_operator "|>"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-elixir/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-elixir/locals.scm
@@ -1,0 +1,215 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; References
+(identifier) @local.reference
+
+(alias) @local.reference
+
+; Module Definitions
+(call
+  target: ((identifier) @_identifier
+    (#eq? @_identifier "defmodule"))
+  (arguments
+    (alias) @local.definition.type))
+
+; Pattern Match Definitions
+(binary_operator
+  ; format-ignore
+  left: 
+    [
+      (identifier) @local.definition.var
+      (_ (identifier) @local.definition.var)
+      (_ (_ (identifier) @local.definition.var))
+      (_ (_ (_ (identifier) @local.definition.var)))
+      (_ (_ (_ (_ (identifier) @local.definition.var))))
+      (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))
+      (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))
+      (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))))))
+      (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))))))
+    ]
+  operator: "=")
+
+; Stab Clause Definitions
+; format-ignore
+(stab_clause
+  left:
+    [
+     (arguments
+      [
+        (identifier) @local.definition.var
+        (_ (identifier) @local.definition.var)
+        (_ (_ (identifier) @local.definition.var))
+        (_ (_ (_ (identifier) @local.definition.var)))
+        (_ (_ (_ (_ (identifier) @local.definition.var))))
+        (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))
+        (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))
+        (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))))))
+        (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))))))
+      ])
+
+    (binary_operator
+      left:
+        (arguments
+          ; format-ignore
+          [
+            (identifier) @local.definition.var
+            (_ (identifier) @local.definition.var)
+            (_ (_ (identifier) @local.definition.var))
+            (_ (_ (_ (identifier) @local.definition.var)))
+            (_ (_ (_ (_ (identifier) @local.definition.var))))
+            (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))
+            (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))
+            (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var)))))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.var))))))))))))))))))))
+          ])
+      operator: "when")
+    ])
+
+; Aliases
+; format-ignore
+(call
+  target:
+    ((identifier) @_identifier
+      (#any-of? @_identifier "require" "alias" "use" "import"))
+  (arguments
+    [
+      (alias) @local.definition.import
+      (_ (alias) @local.definition.import)
+      (_ (_ (alias) @local.definition.import))
+      (_ (_ (_ (alias) @local.definition.import)))
+      (_ (_ (_ (_ (alias) @local.definition.import))))
+    ]))
+
+; Local Function Definitions & Scopes
+; format-ignore
+(call
+  target:
+    ((identifier) @_identifier
+      (#any-of? @_identifier "def" "defp" "defmacro" "defmacrop" "defguard" "defguardp" "defn" "defnp" "for"))
+  (arguments
+    [
+      (identifier) @local.definition.function
+      (binary_operator
+        left: (identifier) @local.definition.function
+        operator: "when")
+      (binary_operator
+        (identifier) @local.definition.parameter)
+      (call
+        target: (identifier) @local.definition.function
+        (arguments
+          [
+            (identifier) @local.definition.parameter
+            (_ (identifier) @local.definition.parameter)
+            (_ (_ (identifier) @local.definition.parameter))
+            (_ (_ (_ (identifier) @local.definition.parameter)))
+            (_ (_ (_ (_ (identifier) @local.definition.parameter))))
+            (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))
+            (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))
+            (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))))))))
+            (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))))))))
+          ]))
+    ]?)
+  (#set! definition.function.scope parent)(do_block)?) @local.scope
+
+; ExUnit Test Definitions & Scopes
+; format-ignore
+(call
+  target:
+    ((identifier) @_identifier
+      (#eq? @_identifier "test"))
+  (arguments
+    [
+      (string)
+      ((string)
+        .
+        ","
+        .
+        [
+          (identifier) @local.definition.parameter
+          (_ (identifier) @local.definition.parameter)
+          (_ (_ (identifier) @local.definition.parameter))
+          (_ (_ (_ (identifier) @local.definition.parameter)))
+          (_ (_ (_ (_ (identifier) @local.definition.parameter))))
+          (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))
+          (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))
+          (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter)))))))))))))))))))
+          (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (_ (identifier) @local.definition.parameter))))))))))))))))))))
+        ])
+    ])
+  (do_block)?) @local.scope
+
+; Stab Clause Scopes
+(stab_clause) @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-go/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-go/folds.scm
@@ -1,0 +1,34 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (const_declaration)
+  (expression_switch_statement)
+  (expression_case)
+  (default_case)
+  (type_switch_statement)
+  (type_case)
+  (for_statement)
+  (func_literal)
+  (function_declaration)
+  (if_statement)
+  (import_declaration)
+  (method_declaration)
+  (type_declaration)
+  (var_declaration)
+  (composite_literal)
+  (literal_element)
+  (block)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-go/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-go/indents.scm
@@ -1,0 +1,63 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (import_declaration)
+  (const_declaration)
+  (var_declaration)
+  (type_declaration)
+  (func_literal)
+  (literal_value)
+  (expression_case)
+  (communication_case)
+  (type_case)
+  (default_case)
+  (block)
+  (call_expression)
+  (parameter_list)
+  (field_declaration_list)
+  (interface_type)
+] @indent.begin
+
+(literal_value
+  "}" @indent.branch)
+
+(block
+  "}" @indent.branch)
+
+(field_declaration_list
+  "}" @indent.branch)
+
+(interface_type
+  "}" @indent.branch)
+
+(const_declaration
+  ")" @indent.branch)
+
+(import_spec_list
+  ")" @indent.branch)
+
+(var_spec_list
+  ")" @indent.branch)
+
+[
+  "}"
+  ")"
+] @indent.end
+
+(parameter_list
+  ")" @indent.branch)
+
+(comment) @indent.ignore

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-go/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-go/injections.scm
@@ -1,0 +1,57 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+(call_expression
+  (selector_expression) @_function
+  (#any-of? @_function
+    "regexp.Match" "regexp.MatchReader" "regexp.MatchString" "regexp.Compile" "regexp.CompilePOSIX"
+    "regexp.MustCompile" "regexp.MustCompilePOSIX")
+  (argument_list
+    .
+    [
+      (raw_string_literal
+        (raw_string_literal_content) @injection.content)
+      (interpreted_string_literal
+        (interpreted_string_literal_content) @injection.content)
+    ]
+    (#set! injection.language "regex")))
+
+((comment) @injection.content
+  (#match? @injection.content "/\\*!([a-zA-Z]+:)?re2c")
+  (#set! injection.language "re2c"))
+
+((call_expression
+  function: (selector_expression
+    field: (field_identifier) @_method)
+  arguments: (argument_list
+    .
+    (interpreted_string_literal
+      (interpreted_string_literal_content) @injection.content)))
+  (#any-of? @_method "Printf" "Sprintf" "Fatalf" "Scanf" "Errorf" "Skipf" "Logf")
+  (#set! injection.language "printf"))
+
+((call_expression
+  function: (selector_expression
+    field: (field_identifier) @_method)
+  arguments: (argument_list
+    (_)
+    .
+    (interpreted_string_literal
+      (interpreted_string_literal_content) @injection.content)))
+  (#any-of? @_method "Fprintf" "Fscanf" "Appendf" "Sscanf")
+  (#set! injection.language "printf"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-go/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-go/locals.scm
@@ -1,0 +1,103 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((function_declaration
+  name: (identifier) @local.definition.function) ; @function
+  )
+
+((method_declaration
+  name: (field_identifier) @local.definition.method) ; @function.method
+  )
+
+(short_var_declaration
+  left: (expression_list
+    (identifier) @local.definition.var))
+
+(var_spec
+  name: (identifier) @local.definition.var)
+
+(parameter_declaration
+  (identifier) @local.definition.var)
+
+(variadic_parameter_declaration
+  (identifier) @local.definition.var)
+
+(for_statement
+  (range_clause
+    left: (expression_list
+      (identifier) @local.definition.var)))
+
+(const_declaration
+  (const_spec
+    name: (identifier) @local.definition.var))
+
+(type_declaration
+  (type_spec
+    name: (type_identifier) @local.definition.type))
+
+; reference
+(identifier) @local.reference
+
+(type_identifier) @local.reference
+
+(field_identifier) @local.reference
+
+((package_identifier) @local.reference
+  (#set! reference.kind "namespace"))
+
+(package_clause
+  (package_identifier) @local.definition.namespace)
+
+(import_spec_list
+  (import_spec
+    name: (package_identifier) @local.definition.namespace))
+
+; Call references
+((call_expression
+  function: (identifier) @local.reference)
+  (#set! reference.kind "call"))
+
+((call_expression
+  function: (selector_expression
+    field: (field_identifier) @local.reference))
+  (#set! reference.kind "call"))
+
+((call_expression
+  function: (parenthesized_expression
+    (identifier) @local.reference))
+  (#set! reference.kind "call"))
+
+((call_expression
+  function: (parenthesized_expression
+    (selector_expression
+      field: (field_identifier) @local.reference)))
+  (#set! reference.kind "call"))
+
+; Scopes
+(func_literal) @local.scope
+
+(source_file) @local.scope
+
+(function_declaration) @local.scope
+
+(if_statement) @local.scope
+
+(block) @local.scope
+
+(expression_switch_statement) @local.scope
+
+(for_statement) @local.scope
+
+(method_declaration) @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-haskell/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-haskell/folds.scm
@@ -1,0 +1,21 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (apply)
+  (do)
+  (function)
+  (import)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-haskell/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-haskell/injections.scm
@@ -1,0 +1,99 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; -----------------------------------------------------------------------------
+; General language injection
+(quasiquote
+  (quoter) @injection.language
+  (quasiquote_body) @injection.content)
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+; -----------------------------------------------------------------------------
+; shakespeare library
+; NOTE: doesn't support templating
+; TODO: add once CoffeeScript parser is added
+; ; CoffeeScript: Text.Coffee
+; (quasiquote
+;  (quoter) @_name
+;  (#eq? @_name "coffee")
+;  ((quasiquote_body) @injection.content
+;   (#set! injection.language "coffeescript")))
+; CSS: Text.Cassius, Text.Lucius
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "cassius" "lucius")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "css"))
+
+; HTML: Text.Hamlet
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "shamlet" "xshamlet" "hamlet" "xhamlet" "ihamlet")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "html"))
+
+; JS: Text.Julius
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "js" "julius")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "javascript"))
+
+; TS: Text.TypeScript
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "tsc" "tscJSX")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "typescript"))
+
+; -----------------------------------------------------------------------------
+; HSX
+(quasiquote
+  (quoter) @_name
+  (#eq? @_name "hsx")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "html"))
+
+; -----------------------------------------------------------------------------
+; Inline JSON from aeson
+(quasiquote
+  (quoter) @_name
+  (#eq? @_name "aesonQQ")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "json"))
+
+; -----------------------------------------------------------------------------
+; SQL
+; postgresql-simple
+(quasiquote
+  (quoter) @injection.language
+  (#eq? @injection.language "sql")
+  (quasiquote_body) @injection.content)
+
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "persistUpperCase" "persistLowerCase" "persistWith")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "haskell_persistent"))
+
+; -----------------------------------------------------------------------------
+; Python
+; inline-python
+(quasiquote
+  (quoter) @injection.language
+  (#any-of? @injection.language "pymain" "pye" "py_" "pyf")
+  (quasiquote_body) @injection.content)

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-html/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-html/folds.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (element)
+  (style_element)
+  (script_element)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-html/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-html/indents.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: html_tags

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-html/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-html/locals.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+(element) @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-java/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-java/folds.scm
@@ -1,0 +1,23 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (block)
+  (class_body)
+  (constructor_declaration)
+  (argument_list)
+  (annotation_argument_list)
+  (import_declaration)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-java/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-java/indents.scm
@@ -1,0 +1,55 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; format-ignore
+[
+  ; ... refers to the portion that this indent query will have effects on
+  (class_body)                        ; { ... } of `class X`
+  (enum_body)                         ; { ... } of `enum X`
+  (interface_body)                    ; { ... } of `interface X`
+  (constructor_body)                  ; { `modifier` X() {...} } inside `class X`
+  (annotation_type_body)              ; { ... } of `@interface X`
+  (block)                             ; { ... } that's not mentioned in this scope
+  (switch_block)                      ; { ... } in `switch X`
+  (array_initializer)                 ; [1, 2]
+  (argument_list)                     ; foo(...)
+  (formal_parameters)                 ; method foo(...)
+  (annotation_argument_list)          ; @Annotation(...)
+  (element_value_array_initializer)   ; { a, b } inside @Annotation()
+] @indent.begin
+
+(expression_statement
+  (method_invocation) @indent.begin)
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @indent.branch
+
+(annotation_argument_list
+  ")" @indent.end) ; This should be a special cased as `()` here doesn't have ending `;`
+
+"}" @indent.end
+
+(line_comment) @indent.ignore
+
+[
+  (ERROR)
+  (block_comment)
+] @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-java/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-java/injections.scm
@@ -1,0 +1,46 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+([
+  (block_comment)
+  (line_comment)
+] @injection.content
+  (#set! injection.language "comment"))
+
+((block_comment) @injection.content
+  (#lua-match? @injection.content "/[*][*][%s]")
+  (#set! injection.language "javadoc"))
+
+; markdown-style javadocs https://openjdk.org/jeps/467
+((line_comment) @injection.content
+  (#lua-match? @injection.content "^///%s")
+  (#set! injection.language "javadoc"))
+
+((method_invocation
+  name: (identifier) @_method
+  arguments: (argument_list
+    .
+    (string_literal
+      .
+      (_) @injection.content)))
+  (#any-of? @_method "format" "printf")
+  (#set! injection.language "printf"))
+
+((method_invocation
+  object: (string_literal
+    (string_fragment) @injection.content)
+  name: (identifier) @_method)
+  (#eq? @_method "formatted")
+  (#set! injection.language "printf"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-java/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-java/locals.scm
@@ -1,0 +1,115 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; SCOPES
+; declarations
+(program) @local.scope
+
+(class_declaration
+  body: (_) @local.scope)
+
+(record_declaration
+  body: (_) @local.scope)
+
+(enum_declaration
+  body: (_) @local.scope)
+
+(lambda_expression) @local.scope
+
+(enhanced_for_statement) @local.scope
+
+; block
+(block) @local.scope
+
+; if/else
+(if_statement) @local.scope ; if+else
+
+(if_statement
+  consequence: (_) @local.scope) ; if body in case there are no braces
+
+(if_statement
+  alternative: (_) @local.scope) ; else body in case there are no braces
+
+; try/catch
+(try_statement) @local.scope ; covers try+catch, individual try and catch are covered by (block)
+
+(catch_clause) @local.scope ; needed because `Exception` variable
+
+; loops
+(for_statement) @local.scope ; whole for_statement because loop iterator variable
+
+(for_statement
+  ; "for" body in case there are no braces
+  body: (_) @local.scope)
+
+(do_statement
+  body: (_) @local.scope)
+
+(while_statement
+  body: (_) @local.scope)
+
+; Functions
+(constructor_declaration) @local.scope
+
+(method_declaration) @local.scope
+
+; DEFINITIONS
+(package_declaration
+  (identifier) @local.definition.namespace)
+
+(class_declaration
+  name: (identifier) @local.definition.type)
+
+(record_declaration
+  name: (identifier) @local.definition.type)
+
+(enum_declaration
+  name: (identifier) @local.definition.enum)
+
+(method_declaration
+  name: (identifier) @local.definition.method)
+
+(local_variable_declaration
+  declarator: (variable_declarator
+    name: (identifier) @local.definition.var))
+
+(enhanced_for_statement
+  ; for (var item : items) {
+  name: (identifier) @local.definition.var)
+
+(formal_parameter
+  name: (identifier) @local.definition.parameter)
+
+(catch_formal_parameter
+  name: (identifier) @local.definition.parameter)
+
+(inferred_parameters
+  (identifier) @local.definition.parameter) ; (x,y) -> ...
+
+(lambda_expression
+  parameters: (identifier) @local.definition.parameter) ; x -> ...
+
+((scoped_identifier
+  (identifier) @local.definition.import)
+  (#has-ancestor? @local.definition.import import_declaration))
+
+(field_declaration
+  declarator: (variable_declarator
+    name: (identifier) @local.definition.field))
+
+; REFERENCES
+(identifier) @local.reference
+
+(type_identifier) @local.reference

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/folds.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: ecma,jsx

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/indents.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: ecma,jsx

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-json/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-json/folds.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (pair)
+  (object)
+  (array)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-json/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-json/indents.scm
@@ -1,0 +1,24 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (object)
+  (array)
+] @indent.begin
+
+[
+  "}"
+  "]"
+] @indent.branch

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-json/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-json/locals.scm
@@ -1,0 +1,19 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (object)
+  (array)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-julia/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-julia/folds.scm
@@ -1,0 +1,29 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (module_definition)
+  (struct_definition)
+  (macro_definition)
+  (function_definition)
+  (if_statement)
+  (try_statement)
+  (for_statement)
+  (while_statement)
+  (let_statement)
+  (quote_statement)
+  (do_clause)
+  (compound_statement)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-julia/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-julia/highlights.scm
@@ -1,0 +1,387 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Identifiers
+(identifier) @variable
+
+(field_expression
+  (identifier) @variable.member .)
+
+; Symbols
+(quote_expression
+  ":" @string.special.symbol
+  [
+    (identifier)
+    (operator)
+  ] @string.special.symbol)
+
+; Function calls
+(call_expression
+  (identifier) @function.call)
+
+(call_expression
+  (field_expression
+    (identifier) @function.call .))
+
+(broadcast_call_expression
+  (identifier) @function.call)
+
+(broadcast_call_expression
+  (field_expression
+    (identifier) @function.call .))
+
+(binary_expression
+  (_)
+  (operator) @_pipe
+  (identifier) @function.call
+  (#any-of? @_pipe "|>" ".|>"))
+
+; Macros
+(macro_identifier
+  "@" @function.macro
+  (identifier) @function.macro)
+
+(macro_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @function.macro)))
+
+; Built-in functions
+; filter(name -> Base.eval(Core, name) isa Core.Builtin, names(Core))
+((identifier) @function.builtin
+  (#any-of? @function.builtin
+    "applicable" "fieldtype" "getfield" "getglobal" "invoke" "isa" "isdefined" "modifyfield!"
+    "modifyglobal!" "nfields" "replacefield!" "replaceglobal!" "setfield!" "setfieldonce!"
+    "setglobal!" "setglobalonce!" "swapfield!" "swapglobal!" "throw" "tuple" "typeassert" "typeof"))
+
+; Type definitions
+(type_head
+  (_) @type.definition)
+
+; Type annotations
+(parametrized_type_expression
+  [
+    (identifier) @type
+    (field_expression
+      (identifier) @type .)
+  ]
+  (curly_expression
+    (_) @type))
+
+(typed_expression
+  (identifier) @type .)
+
+(unary_typed_expression
+  (identifier) @type .)
+
+(where_expression
+  [
+    (curly_expression
+      (_) @type)
+    (_) @type
+  ] .)
+
+(unary_expression
+  (operator) @operator
+  (_) @type
+  (#any-of? @operator "<:" ">:"))
+
+(binary_expression
+  (_) @type
+  (operator) @operator
+  (_) @type
+  (#any-of? @operator "<:" ">:"))
+
+; Built-in types
+; filter(name -> typeof(Base.eval(Core, name)) in [DataType, UnionAll], names(Core))
+((identifier) @type.builtin
+  (#any-of? @type.builtin
+    "AbstractArray" "AbstractChar" "AbstractFloat" "AbstractString" "Any" "ArgumentError" "Array"
+    "AssertionError" "Bool" "BoundsError" "Char" "ConcurrencyViolationError" "Cvoid" "DataType"
+    "DenseArray" "DivideError" "DomainError" "ErrorException" "Exception" "Expr" "Float16" "Float32"
+    "Float64" "Function" "GlobalRef" "IO" "InexactError" "InitError" "Int" "Int128" "Int16" "Int32"
+    "Int64" "Int8" "Integer" "InterruptException" "LineNumberNode" "LoadError" "Method"
+    "MethodError" "Module" "NTuple" "NamedTuple" "Nothing" "Number" "OutOfMemoryError"
+    "OverflowError" "Pair" "Ptr" "QuoteNode" "ReadOnlyMemoryError" "Real" "Ref" "SegmentationFault"
+    "Signed" "StackOverflowError" "String" "Symbol" "Task" "Tuple" "Type" "TypeError" "TypeVar"
+    "UInt" "UInt128" "UInt16" "UInt32" "UInt64" "UInt8" "UndefInitializer" "UndefKeywordError"
+    "UndefRefError" "UndefVarError" "Union" "UnionAll" "Unsigned" "VecElement" "WeakRef"))
+
+; Keywords
+[
+  "global"
+  "local"
+] @keyword
+
+(compound_statement
+  [
+    "begin"
+    "end"
+  ] @keyword)
+
+(quote_statement
+  [
+    "quote"
+    "end"
+  ] @keyword)
+
+(let_statement
+  [
+    "let"
+    "end"
+  ] @keyword)
+
+(if_statement
+  [
+    "if"
+    "end"
+  ] @keyword.conditional)
+
+(elseif_clause
+  "elseif" @keyword.conditional)
+
+(else_clause
+  "else" @keyword.conditional)
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
+
+(try_statement
+  [
+    "try"
+    "end"
+  ] @keyword.exception)
+
+(catch_clause
+  "catch" @keyword.exception)
+
+(finally_clause
+  "finally" @keyword.exception)
+
+(for_statement
+  [
+    "for"
+    "end"
+  ] @keyword.repeat)
+
+(for_binding
+  "outer" @keyword.repeat)
+
+; comprehensions
+(for_clause
+  "for" @keyword.repeat)
+
+(if_clause
+  "if" @keyword.conditional)
+
+(while_statement
+  [
+    "while"
+    "end"
+  ] @keyword.repeat)
+
+[
+  (break_statement)
+  (continue_statement)
+] @keyword.repeat
+
+[
+  "const"
+  "mutable"
+] @keyword.modifier
+
+(function_definition
+  [
+    "function"
+    "end"
+  ] @keyword.function)
+
+(do_clause
+  [
+    "do"
+    "end"
+  ] @keyword.function)
+
+(macro_definition
+  [
+    "macro"
+    "end"
+  ] @keyword)
+
+(return_statement
+  "return" @keyword.return)
+
+(module_definition
+  [
+    "module"
+    "baremodule"
+    "end"
+  ] @keyword.import)
+
+(export_statement
+  "export" @keyword.import)
+
+(public_statement
+  "public" @keyword.import)
+
+(import_statement
+  "import" @keyword.import)
+
+(using_statement
+  "using" @keyword.import)
+
+(import_alias
+  "as" @keyword.import)
+
+(selected_import
+  ":" @punctuation.delimiter)
+
+(struct_definition
+  [
+    "mutable"
+    "struct"
+    "end"
+  ] @keyword.type)
+
+(abstract_definition
+  [
+    "abstract"
+    "type"
+    "end"
+  ] @keyword.type)
+
+(primitive_definition
+  [
+    "primitive"
+    "type"
+    "end"
+  ] @keyword.type)
+
+; Operators & Punctuation
+(operator) @operator
+
+(adjoint_expression
+  "'" @operator)
+
+(range_expression
+  ":" @operator)
+
+(arrow_function_expression
+  "->" @operator)
+
+[
+  "."
+  "..."
+] @punctuation.special
+
+[
+  ","
+  ";"
+  "::"
+] @punctuation.delimiter
+
+; Treat `::` as operator in type contexts, see
+; https://github.com/nvim-treesitter/nvim-treesitter/pull/7392
+(typed_expression
+  "::" @operator)
+
+(unary_typed_expression
+  "::" @operator)
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; Interpolation
+(string_interpolation
+  .
+  "$" @punctuation.special)
+
+(interpolation_expression
+  .
+  "$" @punctuation.special)
+
+; Keyword operators
+((operator) @keyword.operator
+  (#any-of? @keyword.operator "in" "isa"))
+
+(where_expression
+  "where" @keyword.operator)
+
+; Built-in constants
+((identifier) @constant.builtin
+  (#any-of? @constant.builtin "nothing" "missing"))
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "begin" "end")
+  (#has-ancestor? @variable.builtin index_expression))
+
+; Literals
+(boolean_literal) @boolean
+
+(integer_literal) @number
+
+(float_literal) @number.float
+
+((identifier) @number.float
+  (#any-of? @number.float "NaN" "NaN16" "NaN32" "Inf" "Inf16" "Inf32"))
+
+(character_literal) @character
+
+(escape_sequence) @string.escape
+
+(string_literal) @string
+
+(prefixed_string_literal
+  prefix: (identifier) @function.macro) @string
+
+(command_literal) @string.special
+
+(prefixed_command_literal
+  prefix: (identifier) @function.macro) @string.special
+
+((string_literal) @string.documentation
+  .
+  [
+    (abstract_definition)
+    (assignment)
+    (const_statement)
+    (function_definition)
+    (macro_definition)
+    (module_definition)
+    (struct_definition)
+  ])
+
+(source_file
+  (string_literal) @string.documentation
+  .
+  [
+    (identifier)
+    (call_expression)
+  ])
+
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-julia/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-julia/indents.scm
@@ -1,0 +1,67 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (struct_definition)
+  (macro_definition)
+  (function_definition)
+  (compound_statement)
+  (if_statement)
+  (try_statement)
+  (for_statement)
+  (while_statement)
+  (let_statement)
+  (quote_statement)
+  (do_clause)
+  (assignment)
+  (for_binding)
+  (call_expression)
+  (parenthesized_expression)
+  (tuple_expression)
+  (comprehension_expression)
+  (matrix_expression)
+  (vector_expression)
+] @indent.begin
+
+[
+  "end"
+  ")"
+  "]"
+  "}"
+] @indent.end
+
+[
+  "end"
+  ")"
+  "]"
+  "}"
+  (else_clause)
+  (elseif_clause)
+  (catch_clause)
+  (finally_clause)
+] @indent.branch
+
+[
+  (line_comment)
+  (block_comment)
+] @indent.ignore
+
+((argument_list) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+((curly_expression) @indent.align
+  (#set! indent.open_delimiter "{")
+  (#set! indent.close_delimiter "}"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-julia/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-julia/injections.scm
@@ -1,0 +1,57 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Inject markdown in docstrings
+((string_literal
+  (content) @injection.content)
+  .
+  [
+    (module_definition)
+    (abstract_definition)
+    (struct_definition)
+    (function_definition)
+    (macro_definition)
+    (assignment)
+    (const_statement)
+    (call_expression)
+    (identifier)
+  ]
+  (#set! injection.language "markdown"))
+
+; Inject comments
+([
+  (line_comment)
+  (block_comment)
+] @injection.content
+  (#set! injection.language "comment"))
+
+; Inject regex in r"..." and r"""...""" (e.g. r"hello\bworld")
+(prefixed_string_literal
+  prefix: (identifier) @_prefix
+  (content) @injection.content
+  (#eq? @_prefix "r")
+  (#set! injection.language "regex"))
+
+; Inject markdown in md"..." and md"""...""" (e.g. md"**Bold** and _Italics_")
+(prefixed_string_literal
+  prefix: (identifier) @_prefix
+  (content) @injection.content
+  (#eq? @_prefix "md")
+  (#set! injection.language "markdown"))
+
+; Inject bash in `...` and ```...``` (e.g. `git add --help`)
+(command_literal
+  (content) @injection.content
+  (#set! injection.language "bash"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-julia/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-julia/locals.scm
@@ -1,0 +1,90 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; References
+(identifier) @local.reference
+
+; Variables
+(assignment
+  (identifier) @local.definition.var)
+
+(assignment
+  (tuple_expression
+    (identifier) @local.definition.var))
+
+; let/const bindings
+(let_binding
+  (identifier) @local.definition.var)
+
+(let_binding
+  (tuple_expression
+    (identifier) @local.definition.var))
+
+; For bindings
+(for_binding
+  (identifier) @local.definition.var)
+
+(for_binding
+  (tuple_expression
+    (identifier) @local.definition.var))
+
+; Types
+(module_definition
+  (identifier) @local.definition.type)
+
+(struct_definition
+  (identifier) @local.definition.type)
+
+(type_head
+  (identifier) @local.definition.type)
+
+(type_head
+  (binary_expression
+    .
+    (identifier) @local.definition.type))
+
+; Module imports
+(import_statement
+  (identifier) @local.definition.import)
+
+(using_statement
+  (identifier) @local.definition.import)
+
+(selected_import
+  (identifier) @local.definition.import)
+
+; Scopes
+(function_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @local.definition.function))) @local.scope
+
+(macro_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @local.definition.function))) @local.scope
+
+[
+  (quote_statement)
+  (let_statement)
+  (for_statement)
+  (while_statement)
+  (try_statement)
+  (catch_clause)
+  (finally_clause)
+  (do_clause)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-kotlin/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-kotlin/folds.scm
@@ -1,0 +1,28 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (import_list)
+  (when_expression)
+  (control_structure_body)
+  (lambda_literal)
+  (function_body)
+  (primary_constructor)
+  (secondary_constructor)
+  (anonymous_initializer)
+  (class_body)
+  (enum_class_body)
+  (interpolated_expression)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-kotlin/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-kotlin/injections.scm
@@ -1,0 +1,63 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+([
+  (line_comment)
+  (multiline_comment)
+] @injection.content
+  (#set! injection.language "comment"))
+
+; There are 3 ways to define a regex
+;    - "[abc]?".toRegex()
+(call_expression
+  (navigation_expression
+    ((string_literal) @injection.content
+      (#set! injection.language "regex"))
+    (navigation_suffix
+      ((simple_identifier) @_function
+        (#eq? @_function "toRegex")))))
+
+;    - Regex("[abc]?")
+(call_expression
+  ((simple_identifier) @_function
+    (#eq? @_function "Regex"))
+  (call_suffix
+    (value_arguments
+      (value_argument
+        (string_literal) @injection.content
+        (#set! injection.language "regex")))))
+
+;    - Regex.fromLiteral("[abc]?")
+(call_expression
+  (navigation_expression
+    ((simple_identifier) @_class
+      (#eq? @_class "Regex"))
+    (navigation_suffix
+      ((simple_identifier) @_function
+        (#eq? @_function "fromLiteral"))))
+  (call_suffix
+    (value_arguments
+      (value_argument
+        (string_literal) @injection.content
+        (#set! injection.language "regex")))))
+
+; "pi = %.2f".format(3.14159)
+((call_expression
+  (navigation_expression
+    (string_literal) @injection.content
+    (navigation_suffix
+      (simple_identifier) @_method)))
+  (#eq? @_method "format")
+  (#set! injection.language "printf"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-kotlin/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-kotlin/locals.scm
@@ -1,0 +1,93 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Imports
+(package_header
+  .
+  (identifier) @local.definition.namespace)
+
+(import_header
+  (identifier
+    (simple_identifier) @local.definition.import .)
+  (import_alias
+    (type_identifier) @local.definition.import)?)
+
+; Functions
+(function_declaration
+  .
+  (simple_identifier) @local.definition.function
+  (#set! definition.function.scope "parent"))
+
+(class_body
+  (function_declaration
+    .
+    (simple_identifier) @local.definition.method)
+  (#set! definition.method.scope "parent"))
+
+; Variables
+(function_declaration
+  (function_value_parameters
+    (parameter
+      (simple_identifier) @local.definition.parameter)))
+
+(lambda_literal
+  (lambda_parameters
+    (variable_declaration
+      (simple_identifier) @local.definition.parameter)))
+
+; NOTE: temporary fix for treesitter bug that causes delay in file opening
+;(class_body
+;  (property_declaration
+;    (variable_declaration
+;      (simple_identifier) @local.definition.field)))
+(class_declaration
+  (primary_constructor
+    (class_parameter
+      (simple_identifier) @local.definition.field)))
+
+(enum_class_body
+  (enum_entry
+    (simple_identifier) @local.definition.field))
+
+(variable_declaration
+  (simple_identifier) @local.definition.var)
+
+; Types
+(class_declaration
+  (type_identifier) @local.definition.type
+  (#set! definition.type.scope "parent"))
+
+(type_alias
+  (type_identifier) @local.definition.type
+  (#set! definition.type.scope "parent"))
+
+; Scopes
+[
+  (if_expression)
+  (when_expression)
+  (when_entry)
+  (for_statement)
+  (while_statement)
+  (do_while_statement)
+  (lambda_literal)
+  (function_declaration)
+  (primary_constructor)
+  (secondary_constructor)
+  (anonymous_initializer)
+  (class_declaration)
+  (enum_class_body)
+  (enum_entry)
+  (interpolated_expression)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-lua/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-lua/folds.scm
@@ -1,0 +1,27 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (do_statement)
+  (while_statement)
+  (repeat_statement)
+  (if_statement)
+  (for_statement)
+  (function_declaration)
+  (function_definition)
+  (parameters)
+  (arguments)
+  (table_constructor)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-lua/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-lua/indents.scm
@@ -1,0 +1,62 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (function_definition)
+  (function_declaration)
+  (field)
+  (do_statement)
+  (method_index_expression)
+  (while_statement)
+  (repeat_statement)
+  (if_statement)
+  "then"
+  (for_statement)
+  (return_statement)
+  (table_constructor)
+  (arguments)
+] @indent.begin
+
+[
+  "end"
+  "}"
+  "]]"
+] @indent.end
+
+(")" @indent.end
+  (#not-has-parent? @indent.end parameters))
+
+(return_statement
+  (expression_list
+    (function_call))) @indent.dedent
+
+[
+  "end"
+  "then"
+  "until"
+  "}"
+  ")"
+  "elseif"
+  (elseif_statement)
+  "else"
+  (else_statement)
+] @indent.branch
+
+(comment) @indent.auto
+
+(string) @indent.auto
+
+(ERROR
+  "function") @indent.begin

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-markdown/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-markdown/folds.scm
@@ -1,0 +1,27 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+([
+  (fenced_code_block)
+  (indented_code_block)
+  (list_item
+    (list))
+  (section)
+] @fold
+  (#trim! @fold))
+
+(section
+  (list) @fold
+  (#trim! @fold))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-markdown/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-markdown/indents.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+(list_item) @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/folds.scm
@@ -1,0 +1,45 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (let_binding)
+  (external)
+  (type_binding)
+  (exception_definition)
+  (module_binding)
+  (module_type_definition)
+  (open_module)
+  (include_module)
+  (include_module_type)
+  (class_binding)
+  (class_type_binding)
+  (value_specification)
+  (inheritance_specification)
+  (instance_variable_specification)
+  (method_specification)
+  (inheritance_definition)
+  (instance_variable_definition)
+  (method_definition)
+  (class_initializer)
+  (match_case)
+  (attribute)
+  (item_attribute)
+  (floating_attribute)
+  (extension)
+  (item_extension)
+  (quoted_extension)
+  (quoted_item_extension)
+  (comment)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/indents.scm
@@ -1,0 +1,92 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; format-ignore
+[ 
+  (let_binding)                 ; let = ...
+  (type_binding)
+
+  (external)
+  (record_declaration)          ; { foo: bar ... }
+  (structure)                   ; struct ... end
+  (signature)                   ; sig ... end
+  (value_specification)         ; val x: bar
+
+  (do_clause)                   ; do ... done
+  (match_case)
+
+  (field_expression)
+  (application_expression)
+  (parenthesized_expression)    ; ( ... )
+  (record_expression)           ; { foo = bar ... }
+  (list_expression)             ; [...;...]
+  (try_expression)              ; try ... with
+] @indent.begin
+
+; handle if-else if-else case
+(if_expression
+  condition: (_) @indent.begin)
+
+(then_clause) @indent.begin
+
+((else_clause
+  (_) @_not_if) @indent.begin
+  (#not-kind-eq? @_not_if "if_expression"))
+
+((parameter) @indent.begin
+  (#set! indent.start_at_same_line))
+
+(_
+  (ERROR) @indent.begin
+  (#set! indent.start_at_same_line))
+
+(ERROR
+  "|" @indent.begin
+  (#set! indent.start_at_same_line))
+
+(try_expression
+  "with" @indent.branch
+  [
+    (match_case) @indent.dedent
+    (match_case
+      [
+        (parenthesized_expression)
+        (list_expression)
+      ] @indent.dedent)
+  ])
+
+"}" @indent.branch @indent.end
+
+(list_expression
+  "]" @indent.branch)
+
+(parenthesized_expression
+  ")" @indent.branch)
+
+";;" @indent.end
+
+(do_clause
+  "done" @indent.end @indent.branch)
+
+(structure
+  "end" @indent.end @indent.branch)
+
+(signature
+  "end" @indent.end @indent.branch)
+
+[
+  (string)
+  (comment)
+] @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ocaml/injections.scm
@@ -1,0 +1,17 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-perl/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-perl/folds.scm
@@ -1,0 +1,51 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+(comment)+ @fold
+
+(pod) @fold
+
+; fold the block-typed package and class statements only
+(package_statement
+  (block)) @fold
+
+(class_statement
+  (block)) @fold
+
+[
+  (subroutine_declaration_statement)
+  (method_declaration_statement)
+  (conditional_statement)
+  (loop_statement)
+  (for_statement)
+  (cstyle_for_statement)
+  (block_statement)
+  (defer_statement)
+  (phaser_statement)
+] @fold
+
+(try_statement
+  (block) @fold)
+
+(eval_expression
+  (block) @fold)
+
+(anonymous_subroutine_expression) @fold
+
+; perhaps folks want to fold these too?
+[
+  (anonymous_array_expression)
+  (anonymous_hash_expression)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-perl/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-perl/highlights.scm
@@ -1,0 +1,339 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((source_file
+  .
+  (comment) @keyword.directive @nospell)
+  (#lua-match? @keyword.directive "^#!/"))
+
+[
+  "use"
+  "no"
+  "require"
+] @keyword.import
+
+[
+  "if"
+  "elsif"
+  "unless"
+  "else"
+] @keyword.conditional
+
+(conditional_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
+
+[
+  "while"
+  "until"
+  "for"
+  "foreach"
+] @keyword.repeat
+
+("continue" @keyword.repeat
+  (block))
+
+[
+  "try"
+  "catch"
+  "finally"
+] @keyword.exception
+
+"return" @keyword.return
+
+[
+  "sub"
+  "method"
+] @keyword.function
+
+[
+  "async"
+  "await"
+] @keyword.coroutine
+
+[
+  "map"
+  "grep"
+  "sort"
+] @function.builtin
+
+[
+  "package"
+  "class"
+  "role"
+] @keyword.import
+
+[
+  "defer"
+  "do"
+  "eval"
+  "my"
+  "our"
+  "local"
+  "dynamically"
+  "state"
+  "field"
+  "last"
+  "next"
+  "redo"
+  "goto"
+  "undef"
+] @keyword
+
+(_
+  operator: _ @operator)
+
+"\\" @operator
+
+(yadayada) @keyword.exception
+
+(phaser_statement
+  phase: _ @keyword)
+
+(class_phaser_statement
+  phase: _ @keyword)
+
+[
+  "or"
+  "xor"
+  "and"
+  "eq"
+  "equ"
+  "eqr"
+  "ne"
+  "cmp"
+  "lt"
+  "le"
+  "ge"
+  "gt"
+  "isa"
+] @keyword.operator
+
+(eof_marker) @keyword.directive
+
+(data_section) @comment
+
+(pod) @none
+
+[
+  (number)
+  (version)
+] @number
+
+(boolean) @boolean
+
+[
+  (string_literal)
+  (interpolated_string_literal)
+  (quoted_word_list)
+  (command_string)
+  (heredoc_content)
+  (replacement)
+  (transliteration_content)
+] @string
+
+[
+  (heredoc_token)
+  (command_heredoc_token)
+  (heredoc_end)
+] @label
+
+[
+  (escape_sequence)
+  (escaped_delimiter)
+] @string.escape
+
+(_
+  modifiers: _ @character.special)
+
+[
+  (quoted_regexp)
+  (match_regexp)
+  (regexp_content)
+] @string.regexp
+
+(autoquoted_bareword) @string.special
+
+(use_statement
+  (package) @type)
+
+(package_statement
+  (package) @type)
+
+(class_statement
+  (package) @type)
+
+(require_expression
+  (bareword) @type)
+
+(subroutine_declaration_statement
+  name: (bareword) @function)
+
+(method_declaration_statement
+  name: (bareword) @function)
+
+(attribute_name) @attribute
+
+(attribute_value) @string
+
+(label) @label
+
+(statement_label
+  label: _ @label)
+
+(relational_expression
+  operator: "isa"
+  right: (bareword) @type)
+
+(function_call_expression
+  (function) @function.call)
+
+(method_call_expression
+  (method) @function.method.call)
+
+(method_call_expression
+  invocant: (bareword) @type)
+
+(func0op_call_expression
+  function: _ @function.builtin)
+
+(func1op_call_expression
+  function: _ @function.builtin)
+
+; this was a regex for the CLI
+([
+  (function)
+  (expression_statement
+    (bareword))
+] @function.builtin
+  (#any-of? @function.builtin
+    "accept" "atan2" "bind" "binmode" "bless" "crypt" "chmod" "chown" "connect" "die" "dbmopen"
+    "exec" "fcntl" "flock" "formline" "getpriority" "getprotobynumber" "gethostbyaddr"
+    "getnetbyaddr" "getservbyname" "getservbyport" "getsockopt" "glob" "index" "ioctl" "join" "kill"
+    "link" "listen" "mkdir" "msgctl" "msgget" "msgrcv" "msgsend" "open" "opendir" "print" "printf"
+    "push" "pack" "pipe" "return" "rename" "rindex" "read" "recv" "reverse" "say" "select" "seek"
+    "semctl" "semget" "semop" "send" "setpgrp" "setpriority" "seekdir" "setsockopt" "shmctl"
+    "shmread" "shmwrite" "shutdown" "socket" "socketpair" "split" "sprintf" "splice" "substr"
+    "system" "symlink" "syscall" "sysopen" "sysseek" "sysread" "syswrite" "tie" "truncate" "unlink"
+    "unpack" "utime" "unshift" "vec" "warn" "waitpid"))
+
+(function) @function
+
+(_
+  "{" @punctuation.special
+  (varname)
+  "}" @punctuation.special)
+
+(varname
+  (block
+    "{" @punctuation.special
+    "}" @punctuation.special))
+
+([
+  (varname)
+  (filehandle)
+] @variable.builtin
+  (#any-of? @variable.builtin
+    "ENV" "ARGV" "INC" "ARGVOUT" "SIG" "STDIN" "STDOUT" "STDERR" "a" "b" "_"))
+
+((varname) @variable.builtin
+  ; highlights all the reserved ^ vars like ${^THINGS}
+  (#lua-match? @variable.builtin "%^"))
+
+((varname) @variable.builtin
+  ; highlights punc vars and also numeric only like $11
+  (#lua-match? @variable.builtin "^%A+$"))
+
+[
+  (scalar)
+  (array)
+  (hash)
+  (glob)
+  ; arraylen's sigil is kinda special b/c it's not a data type
+  (arraylen
+    "$#" @operator)
+] @variable
+
+; all post deref sigils highlighted as operators, and the unrolly star is a special char
+(postfix_deref
+  [
+    "$"
+    "@"
+    "%"
+    "*"
+    "$#"
+  ] @operator
+  "*" @character.special)
+
+(slices
+  [
+    arrayref: _
+    hashref: _
+  ]
+  [
+    "@"
+    "%"
+  ] @operator)
+
+; except for subref deref, b/c that's actually a function call
+(amper_deref_expression
+  [
+    "&"
+    "*"
+  ] @function.call)
+
+; mark hash or glob keys that are any form of string in any form of access
+(_
+  "{"
+  [
+    (autoquoted_bareword)
+    (_
+      (string_content))
+  ] @variable.member
+  "}")
+
+; mark stringies on the LHS of a fat comma as a hash key, b/c that's usually what it
+; denotes somewhat
+(_
+  [
+    (autoquoted_bareword)
+    (_
+      (string_content))
+  ] @variable.member
+  .
+  "=>"
+  (_))
+
+(comment) @comment @spell
+
+[
+  "=>"
+  ","
+  ";"
+  "->"
+] @punctuation.delimiter
+
+([
+  "["
+  "]"
+  "{"
+  "}"
+  "("
+  ")"
+] @punctuation.bracket
+  ; priority hack so nvim + ts-cli behave the same
+  (#set! priority 90))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-perl/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-perl/injections.scm
@@ -1,0 +1,30 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; an injections.scm file for nvim-treesitter
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((pod) @injection.content
+  (#set! injection.language "pod"))
+
+((substitution_regexp
+  (replacement) @injection.content
+  (substitution_regexp_modifiers) @_modifiers)
+  ; match if there's a single `e` in the modifiers list
+  (#lua-match? @_modifiers "e")
+  (#not-lua-match? @_modifiers "e.*e")
+  (#set! injection.language "perl")
+  (#set! injection.include-children))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-php/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-php/folds.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: php_only

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-php/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-php/indents.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: php_only

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-php/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-php/locals.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: php_only

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-python/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-python/folds.scm
@@ -1,0 +1,43 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (function_definition)
+  (class_definition)
+  (while_statement)
+  (for_statement)
+  (if_statement)
+  (with_statement)
+  (try_statement)
+  (match_statement)
+  (import_from_statement)
+  (parameters)
+  (argument_list)
+  (parenthesized_expression)
+  (generator_expression)
+  (list_comprehension)
+  (set_comprehension)
+  (dictionary_comprehension)
+  (tuple)
+  (list)
+  (set)
+  (dictionary)
+  (string)
+] @fold
+
+[
+  (import_statement)
+  (import_from_statement)
+]+ @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-python/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-python/indents.scm
@@ -1,0 +1,228 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (import_from_statement)
+  (generator_expression)
+  (list_comprehension)
+  (set_comprehension)
+  (dictionary_comprehension)
+  (tuple_pattern)
+  (list_pattern)
+  (binary_operator)
+  (lambda)
+  (concatenated_string)
+] @indent.begin
+
+((list) @indent.align
+  (#set! indent.open_delimiter "[")
+  (#set! indent.close_delimiter "]"))
+
+((dictionary) @indent.align
+  (#set! indent.open_delimiter "{")
+  (#set! indent.close_delimiter "}"))
+
+((set) @indent.align
+  (#set! indent.open_delimiter "{")
+  (#set! indent.close_delimiter "}"))
+
+((parenthesized_expression) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+((for_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((if_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((while_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((try_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+(ERROR
+  "try"
+  .
+  ":"
+  (#set! indent.immediate 1)) @indent.begin
+
+(ERROR
+  "try"
+  .
+  ":"
+  (ERROR
+    (block
+      (expression_statement
+        (identifier) @_except) @indent.branch))
+  (#eq? @_except "except"))
+
+((function_definition) @indent.begin
+  (#set! indent.immediate 1))
+
+((class_definition) @indent.begin
+  (#set! indent.immediate 1))
+
+((with_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((match_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((case_clause) @indent.begin
+  (#set! indent.immediate 1))
+
+; if (cond1
+;     or cond2
+;         or cond3):
+;     pass
+;
+(if_statement
+  condition: (parenthesized_expression) @indent.align
+  (#lua-match? @indent.align "^%([^\n]")
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+
+; while (
+;     cond1
+;     or cond2
+;         or cond3):
+;     pass
+;
+(while_statement
+  condition: (parenthesized_expression) @indent.align
+  (#lua-match? @indent.align "[^\n ]%)$")
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+
+; if (
+;     cond1
+;     or cond2
+;         or cond3):
+;     pass
+;
+(if_statement
+  condition: (parenthesized_expression) @indent.align
+  (#lua-match? @indent.align "[^\n ]%)$")
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+
+(ERROR
+  "(" @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  .
+  (_))
+
+((argument_list) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+((parameters) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+((parameters) @indent.align
+  (#lua-match? @indent.align "[^\n ]%)$")
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+
+((tuple) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+(ERROR
+  "[" @indent.align
+  (#set! indent.open_delimiter "[")
+  (#set! indent.close_delimiter "]")
+  .
+  (_))
+
+(ERROR
+  "{" @indent.align
+  (#set! indent.open_delimiter "{")
+  (#set! indent.close_delimiter "}")
+  .
+  (_))
+
+[
+  (break_statement)
+  (continue_statement)
+] @indent.dedent
+
+(ERROR
+  (_) @indent.branch
+  ":"
+  .
+  (#lua-match? @indent.branch "^else"))
+
+(ERROR
+  (_) @indent.branch @indent.dedent
+  ":"
+  .
+  (#lua-match? @indent.branch "^elif"))
+
+(generator_expression
+  ")" @indent.end)
+
+(list_comprehension
+  "]" @indent.end)
+
+(set_comprehension
+  "}" @indent.end)
+
+(dictionary_comprehension
+  "}" @indent.end)
+
+(tuple_pattern
+  ")" @indent.end)
+
+(list_pattern
+  "]" @indent.end)
+
+(return_statement
+  [
+    (_) @indent.end
+    (_
+      [
+        (_)
+        ")"
+        "}"
+        "]"
+      ] @indent.end .)
+    (attribute
+      attribute: (_) @indent.end)
+    (call
+      arguments: (_
+        ")" @indent.end))
+    "return" @indent.end
+  ] .)
+
+[
+  ")"
+  "]"
+  "}"
+  (elif_clause)
+  (else_clause)
+  (except_clause)
+  (finally_clause)
+] @indent.branch
+
+(string) @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-python/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-python/injections.scm
@@ -1,0 +1,33 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+(call
+  function: (attribute
+    object: (identifier) @_re)
+  arguments: (argument_list
+    .
+    (string
+      (string_content) @injection.content))
+  (#eq? @_re "re")
+  (#set! injection.language "regex"))
+
+((binary_operator
+  left: (string
+    (string_content) @injection.content)
+  operator: "%")
+  (#set! injection.language "printf"))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-python/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-python/locals.scm
@@ -1,0 +1,139 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Program structure
+(module) @local.scope
+
+(class_definition
+  body: (block
+    (expression_statement
+      (assignment
+        left: (identifier) @local.definition.field)))) @local.scope
+
+(class_definition
+  body: (block
+    (expression_statement
+      (assignment
+        left: (_
+          (identifier) @local.definition.field))))) @local.scope
+
+; Imports
+(aliased_import
+  alias: (identifier) @local.definition.import) @local.scope
+
+(import_statement
+  name: (dotted_name
+    (identifier) @local.definition.import)) @local.scope
+
+(import_from_statement
+  name: (dotted_name
+    (identifier) @local.definition.import)) @local.scope
+
+; Function with parameters, defines parameters
+(parameters
+  (identifier) @local.definition.parameter)
+
+(default_parameter
+  (identifier) @local.definition.parameter)
+
+(typed_parameter
+  (identifier) @local.definition.parameter)
+
+(typed_default_parameter
+  (identifier) @local.definition.parameter)
+
+; *args parameter
+(parameters
+  (list_splat_pattern
+    (identifier) @local.definition.parameter))
+
+; **kwargs parameter
+(parameters
+  (dictionary_splat_pattern
+    (identifier) @local.definition.parameter))
+
+; Function defines function and scope
+((function_definition
+  name: (identifier) @local.definition.function) @local.scope
+  (#set! definition.function.scope "parent"))
+
+((class_definition
+  name: (identifier) @local.definition.type) @local.scope
+  (#set! definition.type.scope "parent"))
+
+(class_definition
+  body: (block
+    (function_definition
+      name: (identifier) @local.definition.method)))
+
+; Loops
+; not a scope!
+(for_statement
+  left: (pattern_list
+    (identifier) @local.definition.var))
+
+(for_statement
+  left: (tuple_pattern
+    (identifier) @local.definition.var))
+
+(for_statement
+  left: (identifier) @local.definition.var)
+
+; not a scope!
+;(while_statement) @local.scope
+; for in list comprehension
+(for_in_clause
+  left: (identifier) @local.definition.var)
+
+(for_in_clause
+  left: (tuple_pattern
+    (identifier) @local.definition.var))
+
+(for_in_clause
+  left: (pattern_list
+    (identifier) @local.definition.var))
+
+(dictionary_comprehension) @local.scope
+
+(list_comprehension) @local.scope
+
+(set_comprehension) @local.scope
+
+; Assignments
+(assignment
+  left: (identifier) @local.definition.var)
+
+(assignment
+  left: (pattern_list
+    (identifier) @local.definition.var))
+
+(assignment
+  left: (tuple_pattern
+    (identifier) @local.definition.var))
+
+(assignment
+  left: (attribute
+    (identifier)
+    (identifier) @local.definition.field))
+
+; Walrus operator  x := 1
+(named_expression
+  (identifier) @local.definition.var)
+
+(as_pattern
+  alias: (as_pattern_target) @local.definition.var)
+
+; REFERENCES
+(identifier) @local.reference

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ruby/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ruby/folds.scm
@@ -1,0 +1,27 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (method)
+  (singleton_method)
+  (class)
+  (module)
+  (if)
+  (else)
+  (case)
+  (do_block)
+  (singleton_class)
+  (lambda)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ruby/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ruby/indents.scm
@@ -1,0 +1,58 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (class)
+  (singleton_class)
+  (method)
+  (singleton_method)
+  (module)
+  (call)
+  (if)
+  (block)
+  (do_block)
+  (hash)
+  (array)
+  (argument_list)
+  (case)
+  (while)
+  (until)
+  (for)
+  (begin)
+  (unless)
+  (assignment)
+  (parenthesized_statements)
+] @indent.begin
+
+[
+  "end"
+  ")"
+  "}"
+  "]"
+] @indent.end
+
+[
+  "end"
+  ")"
+  "}"
+  "]"
+  (when)
+  (elsif)
+  (else)
+  (rescue)
+  (ensure)
+] @indent.branch
+
+(comment) @indent.ignore

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-ruby/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-ruby/injections.scm
@@ -1,0 +1,38 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+(heredoc_body
+  (heredoc_content) @injection.content
+  (heredoc_end) @injection.language
+  (#downcase! @injection.language))
+
+(regex
+  (string_content) @injection.content
+  (#set! injection.language "regex"))
+
+((call
+  receiver: (identifier) @_receiver
+  method: (identifier) @_method
+  arguments: (argument_list
+    (pair
+      key: (hash_key_symbol)
+      value: (string
+        (string_content) @injection.content))))
+  (#eq? @_receiver "binding")
+  (#any-of? @_method "b" "break")
+  (#set! injection.self))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-rust/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-rust/folds.scm
@@ -1,0 +1,40 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (mod_item)
+  (foreign_mod_item)
+  (function_item)
+  (struct_item)
+  (trait_item)
+  (enum_item)
+  (impl_item)
+  (type_item)
+  (union_item)
+  (const_item)
+  (let_declaration)
+  (loop_expression)
+  (for_expression)
+  (while_expression)
+  (if_expression)
+  (match_expression)
+  (call_expression)
+  (array_expression)
+  (macro_definition)
+  (macro_invocation)
+  (attribute_item)
+  (block)
+  (use_declaration)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-rust/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-rust/indents.scm
@@ -1,0 +1,132 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (mod_item)
+  (struct_item)
+  (enum_item)
+  (impl_item)
+  (struct_expression)
+  (struct_pattern)
+  (tuple_struct_pattern)
+  (tuple_expression)
+  (tuple_type)
+  (tuple_pattern)
+  (match_block)
+  (call_expression)
+  (assignment_expression)
+  (arguments)
+  (block)
+  (where_clause)
+  (use_list)
+  (array_expression)
+  (ordered_field_declaration_list)
+  (field_declaration_list)
+  (enum_variant_list)
+  (parameters)
+  (token_tree)
+  (token_repetition)
+  (macro_definition)
+] @indent.begin
+
+; Typing in "(" inside macro definitions breaks the tree entirely
+; Making macro_definition becoming errors
+; Offset this by adding back one indent for start of macro rules
+(ERROR
+  .
+  "macro_rules!"
+  [
+    "("
+    "{"
+    "["
+  ] @indent.begin
+  (#set! indent.immediate)
+  (#set! indent.start_at_same_line))
+
+(macro_definition
+  [
+    ")"
+    "}"
+    "]"
+  ] @indent.end)
+
+(trait_item
+  body: (_) @indent.begin)
+
+(string_literal
+  (escape_sequence)) @indent.begin
+
+(block
+  "}" @indent.end)
+
+(enum_item
+  body: (enum_variant_list
+    "}" @indent.end))
+
+(impl_item
+  body: (declaration_list
+    "}" @indent.end))
+
+(match_expression
+  body: (match_block
+    "}" @indent.end))
+
+(mod_item
+  body: (declaration_list
+    "}" @indent.end))
+
+(struct_item
+  body: (field_declaration_list
+    "}" @indent.end))
+
+(struct_expression
+  body: (field_initializer_list
+    "}" @indent.end))
+
+(struct_pattern
+  "}" @indent.end)
+
+(tuple_struct_pattern
+  ")" @indent.end)
+
+(tuple_type
+  ")" @indent.end)
+
+(tuple_pattern
+  ")" @indent.end)
+
+(trait_item
+  body: (declaration_list
+    "}" @indent.end))
+
+(impl_item
+  (where_clause) @indent.dedent)
+
+[
+  "where"
+  ")"
+  "]"
+  "}"
+] @indent.branch
+
+(impl_item
+  (declaration_list) @indent.branch)
+
+[
+  (line_comment)
+  (string_literal)
+] @indent.ignore
+
+(raw_string_literal) @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-rust/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-rust/locals.scm
@@ -1,0 +1,113 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Imports
+(extern_crate_declaration
+  name: (identifier) @local.definition.import)
+
+(use_declaration
+  argument: (scoped_identifier
+    name: (identifier) @local.definition.import))
+
+(use_as_clause
+  alias: (identifier) @local.definition.import)
+
+(use_list
+  (identifier) @local.definition.import) ; use std::process::{Child, Command, Stdio};
+
+; Functions
+(function_item
+  name: (identifier) @local.definition.function)
+
+(function_item
+  name: (identifier) @local.definition.method
+  parameters: (parameters
+    (self_parameter)))
+
+; Variables
+(parameter
+  pattern: (identifier) @local.definition.var)
+
+(let_declaration
+  pattern: (identifier) @local.definition.var)
+
+(const_item
+  name: (identifier) @local.definition.var)
+
+(tuple_pattern
+  (identifier) @local.definition.var)
+
+(let_condition
+  pattern: (_
+    (identifier) @local.definition.var))
+
+(tuple_struct_pattern
+  (identifier) @local.definition.var)
+
+(closure_parameters
+  (identifier) @local.definition.var)
+
+(self_parameter
+  (self) @local.definition.var)
+
+(for_expression
+  pattern: (identifier) @local.definition.var)
+
+; Types
+(struct_item
+  name: (type_identifier) @local.definition.type)
+
+(enum_item
+  name: (type_identifier) @local.definition.type)
+
+; Fields
+(field_declaration
+  name: (field_identifier) @local.definition.field)
+
+(enum_variant
+  name: (identifier) @local.definition.field)
+
+; References
+(identifier) @local.reference
+
+((type_identifier) @local.reference
+  (#set! reference.kind "type"))
+
+((field_identifier) @local.reference
+  (#set! reference.kind "field"))
+
+; Macros
+(macro_definition
+  name: (identifier) @local.definition.macro)
+
+; Module
+(mod_item
+  name: (identifier) @local.definition.namespace)
+
+; Scopes
+[
+  (block)
+  (function_item)
+  (closure_expression)
+  (while_expression)
+  (for_expression)
+  (loop_expression)
+  (if_expression)
+  (match_expression)
+  (match_arm)
+  (struct_item)
+  (enum_item)
+  (impl_item)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-scala/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-scala/folds.scm
@@ -1,0 +1,31 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+(call_expression
+  (block) @fold)
+
+[
+  (class_definition)
+  (trait_definition)
+  (object_definition)
+  (function_definition)
+  (val_definition)
+  (import_declaration)
+  (while_expression)
+  (do_while_expression)
+  (for_expression)
+  (try_expression)
+  (match_expression)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-scala/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-scala/injections.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((block_comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-sql/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-sql/folds.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+(statement) @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-sql/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-sql/injections.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((marginalia) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-swift/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-swift/folds.scm
@@ -1,0 +1,50 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; format-ignore
+[
+  (protocol_body)               ; protocol Foo { ... }
+  (class_body)                  ; class Foo { ... }
+  (enum_class_body)             ; enum Foo { ... }
+  (function_body)               ; func Foo (...) {...}
+  (computed_property)           ; { ... }
+
+  (computed_getter)             ; get { ... }
+  (computed_setter)             ; set { ... }
+
+  (do_statement)
+  (if_statement)
+  (for_statement)
+  (switch_statement)
+  (while_statement)
+  (guard_statement)
+  (switch_entry)
+
+  (type_parameters)             ; x<Foo>
+  (tuple_type)                  ; (...)
+  (array_type)                  ; [String]
+  (dictionary_type)             ; [Foo: Bar]
+
+  (call_expression)             ; callFunc(...)
+  (tuple_expression)            ; ( foo + bar )
+  (array_literal)               ; [ foo, bar ]
+  (dictionary_literal)          ; [ foo: bar, x: y ]
+  (lambda_literal) 
+  (willset_didset_block)
+  (willset_clause)
+  (didset_clause)
+
+  (import_declaration)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-swift/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-swift/indents.scm
@@ -1,0 +1,137 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; format-ignore
+[
+  ; ... refers to the section that will get affected by this indent.begin capture
+  (protocol_body)               ; protocol Foo { ... }
+  (class_body)                  ; class Foo { ... }
+  (enum_class_body)             ; enum Foo { ... }
+  (function_declaration)        ; func Foo (...) {...}
+  (init_declaration)            ; init(...) {...}
+  (deinit_declaration)          ; deinit {...}
+  (computed_property)           ; { ... }
+  (subscript_declaration)       ; subscript Foo(...) { ... }
+
+  (computed_getter)             ; get { ... }
+  (computed_setter)             ; set { ... }
+
+  (assignment)                  ; a = b
+
+  (control_transfer_statement)  ; return ...
+  (for_statement)
+  (while_statement)
+  (repeat_while_statement)
+  (do_statement)
+  (if_statement)
+  (switch_statement)
+  (guard_statement)
+
+  (type_parameters)             ; x<Foo>
+  (tuple_type)                  ; (...)
+  (array_type)                  ; [String]
+  (dictionary_type)             ; [Foo: Bar]
+
+  (call_expression)             ; callFunc(...)
+  (tuple_expression)            ; ( foo + bar )
+  (array_literal)               ; [ foo, bar ]
+  (dictionary_literal)          ; [ foo: bar, x: y ]
+  (lambda_literal) 
+  (willset_didset_block)
+  (willset_clause)
+  (didset_clause)
+] @indent.begin
+
+(init_declaration) @indent.begin
+
+(init_declaration
+  [
+    "init"
+    "("
+  ] @indent.branch)
+
+; indentation for init parameters
+(init_declaration
+  ")" @indent.branch @indent.end)
+
+(init_declaration
+  (parameter) @indent.begin
+  (#set! indent.immediate))
+
+; @something(...)
+(modifiers
+  (attribute) @indent.begin)
+
+(function_declaration
+  (modifiers
+    .
+    (attribute)
+    (_)* @indent.branch)
+  .
+  _ @indent.branch
+  (#not-kind-eq? @indent.branch "type_parameters" "parameter"))
+
+(ERROR
+  [
+    "<"
+    "{"
+    "("
+    "["
+  ]) @indent.begin
+
+; if-elseif
+(if_statement
+  (if_statement) @indent.dedent)
+
+; case Foo:
+; default Foo:
+; @attribute default Foo:
+(switch_entry
+  .
+  _ @indent.branch)
+
+(function_declaration
+  ")" @indent.branch)
+
+(type_parameters
+  ">" @indent.branch @indent.end .)
+
+(tuple_expression
+  ")" @indent.branch @indent.end)
+
+(value_arguments
+  ")" @indent.branch @indent.end)
+
+(tuple_type
+  ")" @indent.branch @indent.end)
+
+(modifiers
+  (attribute
+    ")" @indent.branch @indent.end))
+
+[
+  "}"
+  "]"
+] @indent.branch @indent.end
+
+[
+  ; (ERROR)
+  (comment)
+  (multiline_comment)
+  (raw_str_part)
+  (multi_line_string_literal)
+] @indent.auto
+
+(directive) @indent.ignore

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-swift/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-swift/injections.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+([
+  (comment)
+  (multiline_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-toml/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-toml/folds.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (table)
+  (array)
+  (table_array_element)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-toml/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-toml/indents.scm
@@ -1,0 +1,26 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (array)
+  (inline_table)
+] @indent.begin
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @indent.branch

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-toml/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-toml/injections.scm
@@ -1,0 +1,17 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-toml/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-toml/locals.scm
@@ -1,0 +1,19 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (table)
+  (table_array_element)
+] @local.scope

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-typescript/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-typescript/folds.scm
@@ -1,0 +1,23 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: ecma
+
+[
+  (interface_declaration)
+  (internal_module)
+  (type_alias_declaration)
+  (enum_declaration)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-typescript/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-typescript/indents.scm
@@ -1,0 +1,22 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: ecma
+
+[
+  (enum_declaration)
+  (interface_declaration)
+  (object_type)
+] @indent.begin

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-typescript/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-typescript/injections.scm
@@ -1,0 +1,16 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; inherits: ecma

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-verilog/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-verilog/folds.scm
@@ -1,0 +1,38 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (seq_block)
+  (function_body_declaration)
+  (task_body_declaration)
+  (generate_block)
+  (always_construct)
+  (property_declaration)
+  (checker_declaration)
+  (class_declaration)
+  (config_declaration)
+  (covergroup_declaration)
+  (clocking_declaration)
+  (interface_declaration)
+  (module_declaration)
+  (package_declaration)
+  (module_instantiation)
+  (program_declaration)
+  (specify_block)
+  (generate_region)
+  (package_import_declaration)
+  (text_macro_definition)
+  (include_compiler_directive)+
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-verilog/highlights.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-verilog/highlights.scm
@@ -1,0 +1,620 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Keywords
+[
+  "begin"
+  "end"
+  "generate"
+  "endgenerate"
+  (module_keyword)
+  "endmodule"
+  "program"
+  "endprogram"
+  "package"
+  "endpackage"
+  "checker"
+  "endchecker"
+  "config"
+  "endconfig"
+  "pure"
+  "virtual"
+  "extends"
+  "implements"
+  "super"
+  (class_item_qualifier)
+  "parameter"
+  "localparam"
+  "defparam"
+  "assign"
+  "modport"
+  "fork"
+  "join"
+  "join_none"
+  "join_any"
+  "default"
+  "break"
+  "tagged"
+  "extern"
+  "alias"
+  "posedge"
+  "negedge"
+  "bind"
+  "expect"
+  "type"
+  "void"
+  "coverpoint"
+  "cross"
+  "nettype"
+  "export"
+  "force"
+  "release"
+  "timeunit"
+  "timeprecision"
+  "sequence"
+  "endsequence"
+  "property"
+  "endproperty"
+  "clocking"
+  "endclocking"
+  "covergroup"
+  "endgroup"
+  "specify"
+  "endspecify"
+  "primitive"
+  "endprimitive"
+  "wait"
+  "wait_order"
+  "const"
+  "constraint"
+  "unique"
+  "do"
+  "genvar"
+  "inside"
+  "rand"
+  "continue"
+  "randc"
+  "event"
+  "global"
+  "ref"
+  "initial"
+  "string"
+  (unique_priority)
+  (bins_keyword)
+  (always_keyword)
+] @keyword
+
+[
+  "class"
+  "endclass"
+  "interface"
+  "endinterface"
+  "enum"
+  "struct"
+  "union"
+  "typedef"
+] @keyword.type
+
+[
+  "function"
+  "endfunction"
+  "task"
+  "endtask"
+] @keyword.function
+
+"return" @keyword.return
+
+[
+  "for"
+  "foreach"
+  "repeat"
+  "forever"
+  "while"
+] @keyword.repeat
+
+; for
+(loop_generate_construct
+  (generate_block
+    [
+      "begin"
+      "end"
+    ] @keyword.conditional))
+
+; foreach
+(loop_statement
+  (statement
+    (statement_item
+      (seq_block
+        [
+          "begin"
+          "end"
+        ] @keyword.conditional))))
+
+; repeat forever while
+(loop_statement
+  (statement_or_null
+    (statement
+      (statement_item
+        (seq_block
+          [
+            "begin"
+            "end"
+          ] @keyword.conditional)))))
+
+[
+  "if"
+  "else"
+  "iff"
+  (case_keyword)
+  "endcase"
+] @keyword.conditional
+
+[
+  "="
+  "-"
+  "+"
+  "/"
+  "*"
+  "^"
+  "&"
+  "|"
+  "&&"
+  "||"
+  "<="
+  "=="
+  "!="
+  "==="
+  "!=="
+  "-:"
+  "<"
+  ">"
+  ">="
+  "%"
+  ">>"
+  "<<"
+  "|="
+  "|=>"
+  "|->"
+  ">>>"
+  "<<<"
+  "->>"
+  "->"
+  "=>"
+  "*>"
+  ".*"
+  (unary_operator)
+  (inc_or_dec_operator)
+  (queue_dimension)
+] @operator
+
+"#" @constructor
+
+[
+  ";"
+  "::"
+  ","
+  "."
+  ":"
+] @punctuation.delimiter
+
+(conditional_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
+
+[
+  "["
+  "]"
+  "("
+  ")"
+  "{"
+  "}"
+  "'{"
+] @punctuation.bracket
+
+[
+  "or"
+  "and"
+] @keyword.operator
+
+[
+  "input"
+  "output"
+  "inout"
+  "signed"
+  "unsigned"
+  "assert"
+  "cover"
+  "assume"
+  "disable"
+  "automatic"
+  "static"
+  (dpi_function_import_property)
+  (dpi_task_import_property)
+] @keyword.modifier
+
+[
+  "include"
+  "import"
+  "directive_include"
+] @keyword.import
+
+(comment) @comment @spell
+
+[
+  "@"
+  (cycle_delay_range)
+  (delay_control)
+  (cycle_delay)
+  (attribute_instance)
+] @attribute
+
+(attribute_instance
+  (attr_spec
+    (simple_identifier) @property))
+
+[
+  (integral_number)
+  (unbased_unsized_literal)
+  (fixed_point_number)
+  (unsigned_number)
+] @number
+
+[
+  (net_type)
+  (integer_vector_type)
+  (time_unit)
+  (integer_atom_type)
+  (non_integer_type)
+] @type.builtin
+
+(data_type
+  (simple_identifier) @type.builtin)
+
+; variable
+(list_of_variable_decl_assignments
+  (variable_decl_assignment
+    name: (simple_identifier) @variable))
+
+(hierarchical_identifier
+  (simple_identifier) @variable)
+
+(tf_port_item
+  (simple_identifier) @variable)
+
+port_name: (simple_identifier) @variable
+
+(port
+  (simple_identifier) @variable)
+
+(list_of_port_identifiers
+  (simple_identifier) @variable)
+
+(net_lvalue
+  (simple_identifier) @variable)
+
+(sequence_port_item
+  (simple_identifier) @variable)
+
+(property_port_item
+  (simple_identifier) @variable)
+
+(net_decl_assignment
+  (simple_identifier) @variable)
+
+(ERROR
+  (simple_identifier) @variable)
+
+; variable.member
+(hierarchical_identifier
+  (simple_identifier)
+  (simple_identifier) @variable.member)
+
+(select
+  (simple_identifier) @variable.member)
+
+(named_port_connection
+  port_name: (simple_identifier) @variable.member)
+
+(ordered_port_connection
+  (expression
+    (primary
+      (hierarchical_identifier
+        (simple_identifier) @variable.member))))
+
+(coverage_option
+  (simple_identifier) @variable.member)
+
+; variable.builtin
+(method_call_body
+  arguments: (list_of_arguments
+    (expression) @variable.builtin
+    (#any-of? @variable.builtin "this")))
+
+(implicit_class_handle) @variable.builtin
+
+; variable.parameter
+(named_parameter_assignment
+  (simple_identifier) @variable.parameter)
+
+(parameter_declaration
+  (list_of_param_assignments
+    (param_assignment
+      (simple_identifier) @variable.parameter)))
+
+(local_parameter_declaration
+  (list_of_param_assignments
+    (param_assignment
+      (simple_identifier) @variable.parameter)))
+
+; function builtin
+[
+  (simulation_control_task)
+  (system_tf_identifier)
+  (severity_system_task)
+  (randomize_call)
+  (array_or_queue_method_name)
+  "new"
+] @function.builtin
+
+; declaration
+(task_body_declaration
+  .
+  name: (simple_identifier) @function
+  (simple_identifier)? @label)
+
+(function_body_declaration
+  .
+  name: (simple_identifier) @function
+  (simple_identifier)? @label)
+
+(function_body_declaration
+  .
+  (data_type_or_void)
+  name: (simple_identifier) @function
+  (simple_identifier)? @label)
+
+(clocking_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(sequence_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(property_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(class_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(interface_class_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(covergroup_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(package_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(checker_declaration
+  .
+  name: (simple_identifier) @constructor
+  (simple_identifier)? @label)
+
+(interface_declaration
+  .
+  [
+    (simple_identifier) @constructor
+    (interface_nonansi_header
+      (simple_identifier) @constructor)
+    (interface_ansi_header
+      (simple_identifier) @constructor)
+  ]
+  (simple_identifier)? @label)
+
+(module_declaration
+  .
+  [
+    (simple_identifier) @constructor
+    (module_nonansi_header
+      (simple_identifier) @constructor)
+    (module_ansi_header
+      (simple_identifier) @constructor)
+  ]
+  (simple_identifier)? @label)
+
+(program_declaration
+  .
+  [
+    (simple_identifier) @constructor
+    (program_nonansi_header
+      (simple_identifier) @constructor)
+    (program_ansi_header
+      (simple_identifier) @constructor)
+  ]
+  (simple_identifier)? @label)
+
+(generate_block
+  name: (simple_identifier) @label)
+
+; function.call
+(method_call_body
+  name: (simple_identifier) @function.call)
+
+(tf_call
+  (hierarchical_identifier
+    (simple_identifier) @function.call))
+
+; instance
+(module_instantiation
+  instance_type: (simple_identifier) @constructor)
+
+(name_of_instance
+  instance_name: (simple_identifier) @module)
+
+(sequence_instance
+  (hierarchical_identifier
+    (simple_identifier) @module))
+
+(udp_instantiation
+  (simple_identifier) @constructor)
+
+(ansi_port_declaration
+  (interface_port_header
+    interface_name: (simple_identifier) @variable
+    modport_name: (simple_identifier) @variable.member)
+  port_name: (simple_identifier) @variable)
+
+; bind
+(bind_directive
+  (bind_target_scope
+    (simple_identifier) @constructor))
+
+(bind_target_instance
+  (hierarchical_identifier
+    (simple_identifier) @module))
+
+; assertion
+(concurrent_assertion_item
+  (simple_identifier) @label)
+
+; converge
+(cover_point
+  name: (simple_identifier) @label)
+
+(cover_cross
+  name: (simple_identifier) @module)
+
+(list_of_cross_items
+  (simple_identifier) @constructor)
+
+;package
+(package_import_item
+  (simple_identifier) @constructor)
+
+; label
+(seq_block
+  (simple_identifier) @label)
+
+(statement
+  block_name: (simple_identifier) @label)
+
+; dpi
+(dpi_spec_string) @string
+
+c_name: (c_identifier) @function
+
+(dpi_import_export
+  name: (simple_identifier) @function)
+
+; type def
+(class_type
+  (simple_identifier) @constructor)
+
+(class_type
+  (simple_identifier)
+  (simple_identifier) @type)
+
+(data_type
+  (class_scope
+    (class_type
+      (simple_identifier) @constructor)))
+
+(task_prototype
+  name: (simple_identifier) @function)
+
+(function_prototype
+  name: (simple_identifier) @function)
+
+(type_assignment
+  name: (simple_identifier) @type.definition)
+
+(interface_class_type
+  (simple_identifier) @type.definition)
+
+(package_scope
+  (simple_identifier) @constructor)
+
+(data_declaration
+  (type_declaration
+    type_name: (simple_identifier) @type.definition))
+
+(net_declaration
+  (simple_identifier) @type)
+
+(constraint_declaration
+  (simple_identifier) @constructor)
+
+(method_call
+  (primary
+    (hierarchical_identifier
+      (simple_identifier) @constructor)))
+
+(string_literal
+  (quoted_string) @string)
+
+; include
+(include_statement
+  (file_path_spec) @string.special.path)
+
+; directive
+[
+  "directive_define"
+  "directive_default_nettype"
+  "directive_resetall"
+  "directive_timescale"
+  "directive_undef"
+  "directive_undefineall"
+  "directive_ifdef"
+  "directive_ifndef"
+  "directive_elsif"
+  "directive_endif"
+  "directive_else"
+] @keyword.directive.define
+
+(include_compiler_directive
+  (quoted_string) @string.special.path)
+
+(include_compiler_directive
+  (system_lib_string) @string)
+
+(default_nettype_compiler_directive
+  (default_nettype_value) @type.builtin)
+
+(text_macro_definition
+  (text_macro_name
+    (simple_identifier) @keyword.directive))
+
+(text_macro_usage) @keyword.directive
+
+(ifdef_condition
+  (simple_identifier) @keyword.directive)
+
+(undefine_compiler_directive
+  (simple_identifier) @keyword.directive)

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-verilog/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-verilog/injections.scm
@@ -1,0 +1,20 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((macro_text) @injection.content
+  (#set! injection.language "verilog"))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/folds.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/folds.scm
@@ -1,0 +1,19 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (block_mapping_pair)
+  (block_sequence_item)
+] @fold

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/indents.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/indents.scm
@@ -1,0 +1,22 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (block_mapping_pair
+    value: (block_node))
+  (block_sequence_item)
+] @indent.begin
+
+(ERROR) @indent.auto

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/injections.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/injections.scm
@@ -1,0 +1,96 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+; Github actions ("run") / Gitlab CI ("scripts")
+; Taskfile scripts ("cmds", "cmd", "sh")
+(block_mapping_pair
+  key: (flow_node) @_run
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "cmd" "sh")
+  value: (flow_node
+    (plain_scalar
+      (string_scalar) @injection.content)
+    (#set! injection.language "bash")))
+
+(block_mapping_pair
+  key: (flow_node) @_run
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "cmd" "sh")
+  value: (block_node
+    (block_scalar) @injection.content
+    (#set! injection.language "bash")
+    (#offset! @injection.content 0 1 0 0)))
+
+(block_mapping_pair
+  key: (flow_node) @_run
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "sh")
+  value: (block_node
+    (block_sequence
+      (block_sequence_item
+        (flow_node
+          (plain_scalar
+            (string_scalar) @injection.content))
+        (#set! injection.language "bash")))))
+
+(block_mapping_pair
+  key: (flow_node) @_run
+  (#any-of? @_run "script" "before_script" "after_script" "cmds" "sh")
+  value: (block_node
+    (block_sequence
+      (block_sequence_item
+        (block_node
+          (block_scalar) @injection.content
+          (#set! injection.language "bash")
+          (#offset! @injection.content 0 1 0 0))))))
+
+; Prometheus Alertmanager ("expr")
+(block_mapping_pair
+  key: (flow_node) @_expr
+  (#eq? @_expr "expr")
+  value: (flow_node
+    (plain_scalar
+      (string_scalar) @injection.content)
+    (#set! injection.language "promql")))
+
+(block_mapping_pair
+  key: (flow_node) @_expr
+  (#eq? @_expr "expr")
+  value: (block_node
+    (block_scalar) @injection.content
+    (#set! injection.language "promql")
+    (#offset! @injection.content 0 1 0 0)))
+
+(block_mapping_pair
+  key: (flow_node) @_expr
+  (#eq? @_expr "expr")
+  value: (block_node
+    (block_sequence
+      (block_sequence_item
+        (flow_node
+          (plain_scalar
+            (string_scalar) @injection.content))
+        (#set! injection.language "promql")))))
+
+(block_mapping_pair
+  key: (flow_node) @_expr
+  (#eq? @_expr "expr")
+  value: (block_node
+    (block_sequence
+      (block_sequence_item
+        (block_node
+          (block_scalar) @injection.content
+          (#set! injection.language "promql")
+          (#offset! @injection.content 0 1 0 0))))))

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-yaml/locals.scm
@@ -1,0 +1,24 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+[
+  (stream)
+  (document)
+  (block_node)
+] @local.scope
+
+(anchor_name) @local.definition
+
+(alias_name) @local.reference

--- a/Sources/CodeEditLanguages/Resources/tree-sitter-zig/locals.scm
+++ b/Sources/CodeEditLanguages/Resources/tree-sitter-zig/locals.scm
@@ -1,0 +1,111 @@
+; Copyright 2025 nvim-treesitter
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; Definitions
+(function_declaration
+  name: (identifier) @local.definition.function)
+
+(parameter
+  name: (identifier) @local.definition.parameter)
+
+(variable_declaration
+  (identifier) @local.definition.var)
+
+(variable_declaration
+  (identifier) @local.definition.type
+  (enum_declaration))
+
+(container_field
+  type: (identifier) @local.definition.field)
+
+(enum_declaration
+  (function_declaration
+    name: (identifier) @local.definition.method))
+
+(variable_declaration
+  (identifier) @local.definition.type
+  (struct_declaration))
+
+(struct_declaration
+  (function_declaration
+    name: (identifier) @local.definition.method))
+
+(container_field
+  name: (identifier) @local.definition.field)
+
+(variable_declaration
+  (identifier) @local.definition.type
+  (union_declaration))
+
+(union_declaration
+  (function_declaration
+    name: (identifier) @local.definition.method))
+
+(payload
+  (identifier) @local.definition.var)
+
+(block_label
+  (identifier) @local.definition)
+
+; References
+(identifier) @local.reference
+
+(parameter
+  type: (identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(pointer_type
+  (identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(nullable_type
+  (identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(struct_initializer
+  (identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(array_type
+  (_)
+  (identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(slice_type
+  (identifier) @local.reference
+  (#set! reference.kind "type"))
+
+(field_expression
+  member: (identifier) @local.reference
+  (#set! reference.kind "field"))
+
+(call_expression
+  function: (field_expression
+    member: (identifier) @local.reference
+    (#set! reference.kind "function")))
+
+(break_label
+  (identifier) @local.reference)
+
+[
+  (for_statement)
+  (if_statement)
+  (while_statement)
+  (function_declaration)
+  (block)
+  (source_file)
+  (enum_declaration)
+  (struct_declaration)
+] @local.scope


### PR DESCRIPTION
### Description

This PR introduces a new build step, where missing tree-sitter query files are copied from nvim-treesitter. Neovim has done an amazing job curating good tree-sitter language support through queries. They use the same parsers we do, but have implemented a few more queries on top of the ones implemented in the parent language repositories.

I don't want to look like we're just stealing the work neovim has done. Neovim is under the Apache 2.0 license, and each query file used from their project is copied with a copyright notice directing contributors to their repository. Hopefully the sharing of query files means issues found in CodeEdit will be fixed for Neovim as well.

### Related Issues

* https://github.com/CodeEditApp/CodeEditSourceEditor/issues/43 - required to implement code folding using tree-sitter.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

